### PR TITLE
[cmake] Increase required CMake to 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@
 #   make VERBOSE=1
 #
 
-cmake_minimum_required( VERSION 3.10 )
-project( yqpkg )
+cmake_minimum_required(VERSION 3.17)
+project(yqpkg LANGUAGES CXX)
 
 # Options usage:
 #
@@ -65,8 +65,10 @@ if ( WERROR )
   add_compile_options( "-Werror" )
 endif()
 
-# libzypp uses the C++17 standard
+# libzypp and Qt 6 require C++17
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 
 #
 # Descend into subdirectories


### PR DESCRIPTION
Adjust to required version in package/yqpkg.spec
CMake states Qt 6 requires CMake 3.16.
Set project languange, force C++ 17.