### PR TITLE
Qualify endl, dec, hex with Qt namespace

### DIFF
--- a/src/Exception.h
+++ b/src/Exception.h
@@ -372,7 +372,7 @@ void _throw_helper( const EX_t	  &exception,
 	<< "THROW "
 	<< exception.className() << ": "
 	<< exception.what()
-	<< endl;
+	<< Qt::endl;
 
     throw( exception );
 }
@@ -389,7 +389,7 @@ void _caught_helper( const EX_t	   &exception,
 	<< "CAUGHT "
 	<< exception.className() << ": "
 	<< exception.what()
-	<< endl;
+	<< Qt::endl;
 }
 
 
@@ -406,7 +406,7 @@ void _rethrow_helper( const EX_t    &exception,
 	<< "RETHROW "
 	<< exception.className() << ": "
 	<< exception.what()
-	<< endl;
+	<< Qt::endl;
 
     throw;
 }

--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -84,7 +84,7 @@ Logger::~Logger()
 {
     if ( _logFile.isOpen() )
     {
-	// logInfo() << "-- Log End --\n" << endl;
+	// logInfo() << "-- Log End --\n" << Qt::endl;
 	_logFile.close();
     }
 
@@ -144,7 +144,7 @@ void Logger::openLogFile( const QString & filename )
 	    _logStream.setDevice( &_logFile );
 	    _logStream << "\n\n";
 	    log( __FILE__, __LINE__, __FUNCTION__, LogSeverityInfo )
-		<< "-- Log Start --" << endl;
+		<< "-- Log Start --" << Qt::endl;
 	}
 	else
 	{
@@ -275,7 +275,7 @@ void Logger::setLogLevel( Logger *logger, LogSeverity newLevel )
 
 void Logger::newline()
 {
-    _logStream << endl;
+    _logStream << Qt::endl;
 }
 
 
@@ -332,7 +332,7 @@ static void qt_logger( QtMsgType msgType, const char *msg)
     Logger::log( 0, // use default logger
 		 "[Qt]", 0, "", // file, line, function
 		 toLogSeverity( msgType ) )
-	<< msg << endl;
+	<< msg << Qt::endl;
 
     if ( msgType == QtFatalMsg )
     {
@@ -369,7 +369,7 @@ static void qt_logger( QtMsgType msgType,
             Logger::log( 0, // use default logger
                          context.file, context.line, context.function,
                          toLogSeverity( msgType ) )
-                << "[Qt] " << line << endl;
+                << "[Qt] " << line << Qt::endl;
         }
     }
 
@@ -422,20 +422,20 @@ static void qt_logger( QtMsgType msgType,
 
                 QString text = "FATAL: Could not connect to the display.";
                 fprintf( stderr, "\n%s\n", qPrintable( text ) );
-                logError() << text << endl;
+                logError() << text << Qt::endl;
             }
             else
             {
                 fprintf( stderr, "FATAL: %s\n", qPrintable( msg ) );
             }
 
-            logInfo() << "-- Exiting --\n" << endl;
+            logInfo() << "-- Exiting --\n" << Qt::endl;
 	    exit( 1 ); // Don't dump core, just exit
         }
 	else
         {
             fprintf( stderr, "FATAL: %s\n", qPrintable( msg ) );
-            logInfo() << "-- Aborting with core dump --\n" << endl;
+            logInfo() << "-- Aborting with core dump --\n" << Qt::endl;
 	    abort(); // Exit with core dump (it might contain a useful backtrace)
         }
     }
@@ -487,7 +487,7 @@ QString Logger::createLogDir( const QString & rawLogDir )
     if ( (uid_t) dirInfo.ownerId()  != getuid() )
     {
 	logError() << "ERROR: Directory " << logDir
-		   << " is not owned by " << userName() << endl;
+		   << " is not owned by " << userName() << Qt::endl;
 
 	QByteArray nameTemplate( QString( logDir + "-XXXXXX" ).toUtf8() );
 	char * result = mkdtemp( nameTemplate.data() );
@@ -500,7 +500,7 @@ QString Logger::createLogDir( const QString & rawLogDir )
 	else
 	{
 	    logError() << "Could not create log dir " << nameTemplate
-		       << ": " << formatErrno() << endl;
+		       << ": " << formatErrno() << Qt::endl;
 
 	    logDir = "/";
 	    // No permissions to write to /,
@@ -563,7 +563,7 @@ void Logger::logRotate( const QString & logDir,
 	{
 	    bool success = dir.remove( newName );
 #if VERBOSE_ROTATE
-	    logDebug() << "Removing " << newName << ( success ? "" : " FAILED" ) << endl;
+	    logDebug() << "Removing " << newName << ( success ? "" : " FAILED" ) << Qt::endl;
 #else
 	    Q_UNUSED( success );
 #endif
@@ -575,7 +575,7 @@ void Logger::logRotate( const QString & logDir,
 #if VERBOSE_ROTATE
 	    logDebug() << "Renaming " << currentName << " to " << newName
 		       << ( success ? "" : " FAILED" )
-		       << endl;
+		       << Qt::endl;
 #else
 	    Q_UNUSED( success );
 #endif
@@ -593,7 +593,7 @@ void Logger::logRotate( const QString & logDir,
 	{
 	    bool success = dir.remove( match );
 #if VERBOSE_ROTATE
-	    logDebug() << "Removing leftover " << match << ( success ? "" : " FAILED" ) << endl;
+	    logDebug() << "Removing leftover " << match << ( success ? "" : " FAILED" ) << Qt::endl;
 #else
 	    Q_UNUSED( success );
 #endif

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -82,11 +82,11 @@ void MainWindow::showPage( QWidget * page )
         {
             logDebug() << "Showing page " << page->objectName()
                        << " class " << page->metaObject()->className()
-                       << endl;
+                       << Qt::endl;
         }
         else
         {
-            logDebug() << "Showing class " << page->metaObject()->className() << endl;
+            logDebug() << "Showing class " << page->metaObject()->className() << Qt::endl;
         }
 
         _layout->addWidget( page );
@@ -120,7 +120,7 @@ QWidget * MainWindow::findPage( const QString & pageName )
 {
     if ( pageName.isEmpty() )
     {
-        logError() << "Empty page name" << endl;
+        logError() << "Empty page name" << Qt::endl;
         return 0;
     }
 
@@ -135,7 +135,7 @@ QWidget * MainWindow::findPage( const QString & pageName )
             return page;
     }
 
-    logError() << "No page with name \"" << pageName << "\"" << endl;
+    logError() << "No page with name \"" << pageName << "\"" << Qt::endl;
 
     return 0;
 }
@@ -164,6 +164,6 @@ void MainWindow::closeEvent( QCloseEvent * event )
 {
     Q_UNUSED( event );
 
-    logInfo() << "Caught WM_CLOSE" << endl;
+    logInfo() << "Caught WM_CLOSE" << Qt::endl;
     // event->ignore();
 }

--- a/src/PkgCommitPage.cc
+++ b/src/PkgCommitPage.cc
@@ -137,7 +137,7 @@ PkgTasks * PkgCommitPage::pkgTasks()
 
 void PkgCommitPage::fakeCommit()
 {
-    logInfo() << "Simulating package transactions" << endl;
+    logInfo() << "Simulating package transactions" << Qt::endl;
 
     QListWidgetItem * item = _ui->todoList->count() > 0 ?
         _ui->todoList->item( 0 ) : 0;
@@ -158,7 +158,7 @@ void PkgCommitPage::fakeCommit()
         processEvents();
     }
 
-    logInfo() << "Simulating transactions done" << endl;
+    logInfo() << "Simulating transactions done" << Qt::endl;
 }
 
 
@@ -173,15 +173,15 @@ void PkgCommitPage::realCommit()
 
     try
     {
-        logInfo() << "Starting package transactions" << endl;
+        logInfo() << "Starting package transactions" << Qt::endl;
 
         zypp::getZYpp()->commit( commitPolicy() );
 
-        logInfo() << "Package transactions done" << endl;
+        logInfo() << "Package transactions done" << Qt::endl;
     }
     catch ( const zypp::target::TargetAbortedException & ex )
     {
-        logInfo() << "libzypp aborted as requested" << endl;
+        logInfo() << "libzypp aborted as requested" << Qt::endl;
     }
 
 }
@@ -194,13 +194,13 @@ PkgCommitPage::commitPolicy() const
 
     if ( YQPkgApplication::isOptionSet( OptDryRun ) )
     {
-        logInfo() << "dry run" << endl;
+        logInfo() << "dry run" << Qt::endl;
         policy.dryRun( true );
     }
 
     if ( YQPkgApplication::isOptionSet( OptDownloadOnly ) )
     {
-        logInfo() << "download only" << endl;
+        logInfo() << "download only" << Qt::endl;
         policy.downloadMode( zypp::DownloadOnly );
     }
 
@@ -269,7 +269,7 @@ void PkgCommitPage::cancelCommit()
 
     if ( confirm )
     {
-        logInfo() << "Aborting commit. Notifying libzypp..." << endl;
+        logInfo() << "Aborting commit. Notifying libzypp..." << Qt::endl;
         emit abortCommit();
 
         // Wait for libzypp to return from its commit() so it can shut down
@@ -284,7 +284,7 @@ void PkgCommitPage::wmClose()
 
     if ( confirm )
     {
-        logInfo() << "Aborting commit. Notifying libzypp..." << endl;
+        logInfo() << "Aborting commit. Notifying libzypp..." << Qt::endl;
         emit abortCommit();
 
         // Give libzypp some time to shut down properly: Execute yqapp->quit()
@@ -366,9 +366,9 @@ void PkgCommitPage::initProgressData()
             _totalInstalledSize += task->installedSize();
     }
 
-    logDebug() << "total download size:  " << _totalDownloadSize.asString()  << endl;
-    logDebug() << "total installed size: " << _totalInstalledSize.asString() << endl;
-    logDebug() << "total tasks: "          << _totalTasksCount << endl;
+    logDebug() << "total download size:  " << _totalDownloadSize.asString()  << Qt::endl;
+    logDebug() << "total installed size: " << _totalInstalledSize.asString() << Qt::endl;
+    logDebug() << "total tasks: "          << _totalTasksCount << Qt::endl;
 
     // Weights for different sub-tasks of downloading and installing packages:
     // There is a constant cost for doing anything with a package, no matter if
@@ -383,9 +383,9 @@ void PkgCommitPage::initProgressData()
     _pkgActionWeight    = 0.30;
     _pkgFixedCostWeight = 0.10;
 
-    logDebug() << "pkgDownloadWeight:  " << _pkgDownloadWeight  << endl;
-    logDebug() << "pkgActionWeight:    " << _pkgActionWeight    << endl;
-    logDebug() << "pkgFixedCostWeight: " << _pkgFixedCostWeight << endl;
+    logDebug() << "pkgDownloadWeight:  " << _pkgDownloadWeight  << Qt::endl;
+    logDebug() << "pkgActionWeight:    " << _pkgActionWeight    << Qt::endl;
+    logDebug() << "pkgFixedCostWeight: " << _pkgFixedCostWeight << Qt::endl;
 }
 
 
@@ -419,7 +419,7 @@ int PkgCommitPage::currentProgressPercent()
     logVerbose() << "Download  %: "  << downloadPercent
                  << "  weight: "     << _pkgDownloadWeight
                  << "  raw %: "      << percent
-                 << endl;
+                 << Qt::endl;
 #endif
 
     //
@@ -439,7 +439,7 @@ int PkgCommitPage::currentProgressPercent()
         logVerbose() << "Installed %: " << installedPercent
                      << "  weight: "    << _pkgActionWeight
                      << "  raw %: "     << percent
-                     << endl;
+                     << Qt::endl;
 #endif
     }
 
@@ -458,7 +458,7 @@ int PkgCommitPage::currentProgressPercent()
         logVerbose() << "Tasks     %: " << tasksPercent
                      << "  weight: "    << _pkgFixedCostWeight
                      << "  raw %: "     << percent
-                     << endl;
+                     << Qt::endl;
 #endif
     }
 
@@ -470,7 +470,7 @@ int PkgCommitPage::currentProgressPercent()
     float progress   = tasksPercent + downloadPercent + installedPercent;
 
 #if VERBOSE_PROGRESS
-    logVerbose() << "Progress: " << progress << "%" << endl;
+    logVerbose() << "Progress: " << progress << "%" << Qt::endl;
 #endif
 
     return qBound( 0, (int) ( progress + 0.5 ), 100 );
@@ -486,7 +486,7 @@ bool PkgCommitPage::updateTotalProgressBar()
     if ( progress >= 0 && progress > oldProgress )
     {
 #if VERBOSE_PROGRESS
-        logVerbose() << "Updating with " << progress << "%" << endl;
+        logVerbose() << "Updating with " << progress << "%" << Qt::endl;
 #endif
         _ui->totalProgressBar->setValue( progress );
         didUpdate = true;
@@ -509,12 +509,12 @@ void PkgCommitPage::pkgDownloadStart( ZyppRes zyppRes )
 
     if ( ! task )
     {
-        logError() << "Can't find task for " << zyppRes << " in todo" << endl;
+        logError() << "Can't find task for " << zyppRes << " in todo" << Qt::endl;
         return;
     }
 
 #if VERBOSE_TRANSACT
-    logVerbose() << task << endl;
+    logVerbose() << task << Qt::endl;
 #endif
 
     // Move the task from the todo list to the downloads list
@@ -547,12 +547,12 @@ void PkgCommitPage::pkgDownloadProgress( ZyppRes zyppRes, int percent )
 
     if ( ! task )
     {
-        logError() << "Can't find task for " << zyppRes << " in downloads" << endl;
+        logError() << "Can't find task for " << zyppRes << " in downloads" << Qt::endl;
         return;
     }
 
 #if VERBOSE_PROGRESS
-    logVerbose() << task << ": downloaded " << percent << "%" << endl;
+    logVerbose() << task << ": downloaded " << percent << "%" << Qt::endl;
 #endif
 
     if ( percent != task->downloadedPercent() ) // only if there really was a change
@@ -574,12 +574,12 @@ void PkgCommitPage::pkgDownloadEnd( ZyppRes zyppRes )
 
     if ( ! task )
     {
-        logError() << "Can't find task for " << zyppRes << " in downloads" << endl;
+        logError() << "Can't find task for " << zyppRes << " in downloads" << Qt::endl;
         return;
     }
 
 #if VERBOSE_TRANSACT
-    logVerbose() << task << endl;
+    logVerbose() << task << Qt::endl;
 #endif
 
     task->setDownloadedPercent( 100 );
@@ -604,12 +604,12 @@ void PkgCommitPage::pkgCachedNotify( ZyppRes zyppRes )
 
     if ( ! task )
     {
-        logError() << "Can't find task for " << zyppRes << " in todo" << endl;
+        logError() << "Can't find task for " << zyppRes << " in todo" << Qt::endl;
         return;
     }
 
 #if VERBOSE_TRANSACT
-    logVerbose() << task << endl;
+    logVerbose() << task << Qt::endl;
 #endif
 
     // Move the task from the todo list to the downloads list
@@ -757,7 +757,7 @@ void PkgCommitPage::pkgActionStart( ZyppRes       zyppRes,
         {
             logError() << caller << "(): "
                        << "Can't find task for " << zyppRes
-                       << " in either downloads or todo" << endl;
+                       << " in either downloads or todo" << Qt::endl;
             return;
         }
 
@@ -771,7 +771,7 @@ void PkgCommitPage::pkgActionStart( ZyppRes       zyppRes,
     }
 
 #if VERBOSE_TRANSACT
-    logVerbose() << task << endl;
+    logVerbose() << task << Qt::endl;
 #endif
 
     task->setDownloadedPercent( 100 ); // The download is complete for sure
@@ -814,12 +814,12 @@ void PkgCommitPage::pkgActionProgress( ZyppRes       zyppRes,
     {
         logError() << caller << "(): "
                    << "Can't find task for "
-                   << zyppRes << " in doing" << endl;
+                   << zyppRes << " in doing" << Qt::endl;
         return;
     }
 
 #if VERBOSE_PROGRESS
-    logVerbose() << task << ": " << percent << "%" << endl;
+    logVerbose() << task << ": " << percent << "%" << Qt::endl;
 #endif
 
     if ( percent != task->completedPercent() )
@@ -846,12 +846,12 @@ void PkgCommitPage::pkgActionEnd( ZyppRes       zyppRes,
     {
         logError() << caller << "(): "
                    << "Can't find task for " << zyppRes
-                   << " in doing" << endl;
+                   << " in doing" << Qt::endl;
         return;
     }
 
 #if VERBOSE_TRANSACT
-    logVerbose() << task << endl;
+    logVerbose() << task << Qt::endl;
 #endif
 
 
@@ -893,7 +893,7 @@ void PkgCommitPage::pkgActionError( ZyppRes         zyppRes,
 {
     CHECK_PTR( zyppRes );
 
-    logError() << caller << "(): " << zyppRes << ": " << errorMsg << endl;
+    logError() << caller << "(): " << zyppRes << ": " << errorMsg << Qt::endl;
 
     QString msg;
 

--- a/src/PkgTaskListWidget.cc
+++ b/src/PkgTaskListWidget.cc
@@ -95,7 +95,7 @@ PkgTaskListWidgetItem::PkgTaskListWidgetItem( PkgTask *           task,
     if ( parent )
     {
         logDebug() << "New PkgTask item for " << parent->objectName()
-                   << ": " << txt << endl;
+                   << ": " << txt << Qt::endl;
     }
 #endif
 }

--- a/src/PkgTasks.cc
+++ b/src/PkgTasks.cc
@@ -245,7 +245,7 @@ PkgTasks::PkgTasks()
     , _done     ( "done"      )
     , _failed   ( "failed"    )
 {
-    logDebug() << endl;
+    logDebug() << Qt::endl;
 }
 
 
@@ -253,7 +253,7 @@ PkgTasks::~PkgTasks()
 {
     clearAll();
 
-    logDebug() << "Destroying PkgTasks done" << endl;
+    logDebug() << "Destroying PkgTasks done" << Qt::endl;
 }
 
 
@@ -273,7 +273,7 @@ void PkgTasks::nuke( PkgTaskList & list )
     {
         logDebug() << "Nuking PkgTaskList \"" << list.name()
                    << "\"  size:" << list.size()
-                   << endl;
+                   << Qt::endl;
 
         qDeleteAll( list );
         list.clear();
@@ -289,7 +289,7 @@ void PkgTasks::moveTask( PkgTask *      task,
 
     if ( index < 0 )
     {
-        logError() << "Task " << task->name() << " not found in this list" << endl;
+        logError() << "Task " << task->name() << " not found in this list" << Qt::endl;
         return;
     }
 
@@ -361,7 +361,7 @@ void PkgTasks::initFromZypp()
                     task->setInstalledSize( installed->installSize() );
             }
 
-            logInfo() << "New task " << task << endl;
+            logInfo() << "New task " << task << Qt::endl;
             _todo.append( task );
         }
     }

--- a/src/QY2ComboTabWidget.cc
+++ b/src/QY2ComboTabWidget.cc
@@ -86,7 +86,7 @@ QY2ComboTabWidget::showPageIndex( int index )
     {
         QWidget * page = _pages[ index ];
         _widgetStack->setCurrentWidget( page );
-        // yuiDebug() << "Changing current page" << endl;
+        // yuiDebug() << "Changing current page" << Qt::endl;
         emit currentChanged( page );
     }
     else

--- a/src/QY2IconLoader.cc
+++ b/src/QY2IconLoader.cc
@@ -40,7 +40,7 @@ QIcon QY2IconLoader::loadIcon( const QString & iconName )
 
 QIcon QY2IconLoader::loadThemeIcon( const QString & iconName )
 {
-    // logVerbose() << "Using theme icon for " << iconName << endl;
+    // logVerbose() << "Using theme icon for " << iconName << Qt::endl;
 
     return QIcon::fromTheme( iconName );
 }
@@ -50,12 +50,12 @@ QIcon QY2IconLoader::loadIconFromPath( const QString & iconName )
 {
     if ( access( iconName.toUtf8(), R_OK ) != 0 )
     {
-        logWarning() << "Can't open icon file " << iconName << endl;
+        logWarning() << "Can't open icon file " << iconName << Qt::endl;
 
         return QIcon();
     }
 
-    // logVerbose() << "Loading icon from absolute path " << iconName << endl;
+    // logVerbose() << "Loading icon from absolute path " << iconName << Qt::endl;
 
     return QIcon( iconName );
 }
@@ -71,13 +71,13 @@ QIcon QY2IconLoader::loadBuiltInIcon( const QString & iconName )
     if ( QFile( iconPath ).exists() )
         // Using QFile because it can handle Qt resources and their aliases
     {
-        // logVerbose() << "Using built-in icon " << iconName << endl;
+        // logVerbose() << "Using built-in icon " << iconName << Qt::endl;
 
         return QIcon( iconPath );
     }
     else
     {
-        // logWarning() << "No built-in icon " << iconName << endl;
+        // logWarning() << "No built-in icon " << iconName << Qt::endl;
 
         return QIcon();
     }

--- a/src/QY2ListView.cc
+++ b/src/QY2ListView.cc
@@ -157,7 +157,7 @@ QY2ListView::saveColumnWidths()
     for ( int i = 0; i < columnCount(); i++ )
     {
 	int size = header()->sectionSize(i);
-	// yuiMilestone() << "Saving size " << size << " for section " << i << endl;
+	// yuiMilestone() << "Saving size " << size << " for section " << i << Qt::endl;
 	_savedColumnWidth.push_back( size );
     }
 }
@@ -183,7 +183,7 @@ QY2ListView::restoreColumnWidths()
 	    yuiDebug() << "Restoring size " << _savedColumnWidth[i]
 		       << " for section " << i
 		       << " now " << header()->sectionSize(i)
-		       << endl;
+		       << Qt::endl;
 #endif
 	}
     }

--- a/src/SearchFilter.cc
+++ b/src/SearchFilter.cc
@@ -44,7 +44,7 @@ void SearchFilter::guessFilterMode()
 #if 1
     logDebug() << "using filter mode " << toString( _filterMode )
                << " from \"" << _pattern << "\""
-               << endl;
+               << Qt::endl;
 #endif
 
     if ( _filterMode == ExactMatch && _pattern.startsWith( "=" ) )
@@ -104,11 +104,11 @@ bool SearchFilter::matches( const QString & str ) const
         case RegExp:     return str.contains( _regexp );
         case SelectAll:  return true;
         case Auto:
-            logWarning() << "Unexpected filter mode 'Auto' - assuming 'Contains'" << endl;
+            logWarning() << "Unexpected filter mode 'Auto' - assuming 'Contains'" << Qt::endl;
             return str.contains( _pattern );
     }
 
-    logError() << "Undefined filter mode " << toString( _filterMode ) << endl;
+    logError() << "Undefined filter mode " << toString( _filterMode ) << Qt::endl;
     return false;
 }
 

--- a/src/SummaryPage.cc
+++ b/src/SummaryPage.cc
@@ -62,14 +62,14 @@ SummaryPage::SummaryPage( QWidget * parent )
 
 SummaryPage::~SummaryPage()
 {
-    logDebug() << "Destroying SummaryPage..." << endl;
+    logDebug() << "Destroying SummaryPage..." << Qt::endl;
     writeSettings();
 
     if ( _countdownMenu )
         delete _countdownMenu;
 
     delete _ui;
-    logDebug() << "Destroying SummaryPage done" << endl;
+    logDebug() << "Destroying SummaryPage done" << Qt::endl;
 }
 
 
@@ -152,7 +152,7 @@ void SummaryPage::stopCountdown()
 
 void SummaryPage::timeout()
 {
-    logInfo() << "Summary page timeout -> finishing" << endl;
+    logInfo() << "Summary page timeout -> finishing" << Qt::endl;
     // _ui->countdownLabel->setText( "0" );
     MainWindow::processEvents();
 
@@ -207,7 +207,7 @@ void SummaryPage::configureCountdown( QAction * action )
     if ( action )
     {
         _countdownSec = action->data().toInt();
-        logDebug() << "Setting new countdown: " << _countdownSec << endl;
+        logDebug() << "Setting new countdown: " << _countdownSec << Qt::endl;
 
         startCountdown();  // this also updates the widgets
     }

--- a/src/Workflow.cc
+++ b/src/Workflow.cc
@@ -32,7 +32,7 @@ Workflow::Workflow( const WorkflowStepList & steps )
 
     if ( _steps.isEmpty() )
     {
-        logError() << "Empty workflow!" << endl;
+        logError() << "Empty workflow!" << Qt::endl;
         return;
     }
 
@@ -69,7 +69,7 @@ void Workflow::checkDuplicateIds()
 
     if ( ! duplicates.isEmpty() )
     {
-        logError() << "Duplicate workflow step IDs: " << duplicates << endl;
+        logError() << "Duplicate workflow step IDs: " << duplicates << Qt::endl;
         THROW( Exception( "Duplicate worflow step IDs" ) );
     }
 }
@@ -84,7 +84,7 @@ Workflow::step( const QString & id ) const
             return step;
     }
 
-    logWarning() << "No workflow step \"" << id << "\"" << endl;
+    logWarning() << "No workflow step \"" << id << "\"" << Qt::endl;
     return 0;
 }
 
@@ -104,7 +104,7 @@ void Workflow::next()
         else
             logError() << "No workflow step after step " << _currentStep->id()
                        << " (#" << index << ")"
-                       << endl;
+                       << Qt::endl;
     }
 }
 
@@ -113,7 +113,7 @@ void Workflow::back()
 {
     if ( _history.isEmpty() )
     {
-        logWarning() << "Workflow steps history is empty - can't go back any further" << endl;
+        logWarning() << "Workflow steps history is empty - can't go back any further" << Qt::endl;
         return;
     }
 
@@ -135,7 +135,7 @@ void Workflow::activate( WorkflowStep * step, bool goingForward )
 #if VERBOSE_WORKFLOW
         logDebug() << "Going " << QString( goingForward ? "forward" : "backward" )
                    << " to step " << step->id()
-                   << endl;
+                   << Qt::endl;
 #endif
 
         if ( _currentStep )
@@ -155,7 +155,7 @@ void Workflow::activate( WorkflowStep * step, bool goingForward )
 void Workflow::start()
 {
 #if VERBOSE_WORKFLOW
-        logDebug() << "Starting the workflow" << endl;
+        logDebug() << "Starting the workflow" << Qt::endl;
 #endif
 
     restart();
@@ -182,7 +182,7 @@ bool Workflow::atLastStep() const
 
     if ( index < 0 )
     {
-        logError() << "Can't find current step in the steps list" << endl;
+        logError() << "Can't find current step in the steps list" << Qt::endl;
         return true;
     }
 
@@ -197,19 +197,19 @@ void Workflow::pushHistory( WorkflowStep * step )
         if ( ! step->includeInHistory() )
         {
 #if VERBOSE_WORKFLOW
-            logDebug() << "Step " << step->id() << " is excluded from history" << endl;
+            logDebug() << "Step " << step->id() << " is excluded from history" << Qt::endl;
 #endif
         }
         else
         {
 #if VERBOSE_WORKFLOW
-            logDebug() << "Saving step " << step->id() << " to history" << endl;
+            logDebug() << "Saving step " << step->id() << " to history" << Qt::endl;
 #endif
         _history << step;
         }
     }
     else
-        logError() << "Refusing to push null pointer to history" << endl;
+        logError() << "Refusing to push null pointer to history" << Qt::endl;
 }
 
 
@@ -218,7 +218,7 @@ Workflow::popHistory()
 {
     if ( _history.isEmpty() )
     {
-        logError() << "History is empty" << endl;
+        logError() << "History is empty" << Qt::endl;
         return 0;
     }
 
@@ -226,7 +226,7 @@ Workflow::popHistory()
     CHECK_PTR( step );
 
 #if VERBOSE_WORKFLOW
-    logDebug() << "Taking step " << step->id() << " from history" << endl;
+    logDebug() << "Taking step " << step->id() << " from history" << Qt::endl;
 #endif
 
     return step;

--- a/src/YQIconPool.cc
+++ b/src/YQIconPool.cc
@@ -114,21 +114,21 @@ YQIconPool::loadIcon( const QString icon_name, const bool enabled )
 
     if ( QIcon::hasThemeIcon( icon_name ) )
     {
-        // logVerbose() << "Loading theme icon " << icon_name << endl;
+        // logVerbose() << "Loading theme icon " << icon_name << Qt::endl;
 
         QIcon icon = QIcon::fromTheme( icon_name, QIcon( ":/" + icon_name ) );
         iconPixmap = icon.pixmap( QSize( 16, 16 ), enabled ? QIcon::Normal : QIcon::Disabled );
     }
     else
     {
-        // logVerbose() << "Loading built-in icon " << icon_name << endl;
+        // logVerbose() << "Loading built-in icon " << icon_name << Qt::endl;
 
         QIcon icon = QIcon( ":/" + icon_name );
         iconPixmap = icon.pixmap( QSize( 16, 16 ), enabled ? QIcon::Normal : QIcon::Disabled );
     }
 
     if ( !iconPixmap )
-        logError() << "Could not load icon " << icon_name << endl;
+        logError() << "Could not load icon " << icon_name << Qt::endl;
 
     return iconPixmap;
 }

--- a/src/YQPkgAppWorkflowSteps.cc
+++ b/src/YQPkgAppWorkflowSteps.cc
@@ -49,21 +49,21 @@ YQPkgAppWorkflowStep::YQPkgAppWorkflowStep( YQPkgApplication * app,
     , _doProcessEvents( false )
     , _doDeletePage( true )
 {
-    logDebug() << "Creating step " << _id << endl;
+    logDebug() << "Creating step " << _id << Qt::endl;
 }
 
 
 YQPkgAppWorkflowStep::~YQPkgAppWorkflowStep()
 {
-    logDebug() << "Destroying step " << _id << "..." << endl;
+    logDebug() << "Destroying step " << _id << "..." << Qt::endl;
 
     if ( _doDeletePage && _page )
     {
-        logDebug() << "  Deleting page of step " << _id << endl;
+        logDebug() << "  Deleting page of step " << _id << Qt::endl;
         delete _page;
     }
 
-    logDebug() << "Destroying step " << _id << " done" << endl;
+    logDebug() << "Destroying step " << _id << " done" << Qt::endl;
 }
 
 
@@ -86,7 +86,7 @@ void YQPkgAppWorkflowStep::ensurePage()
 
     if ( ! _page )      // Still no page?
     {
-        logError() << "FATAL: Implement one of page() or createPage()" << endl;
+        logError() << "FATAL: Implement one of page() or createPage()" << Qt::endl;
         CHECK_PTR( _page );
     }
 
@@ -97,7 +97,7 @@ void YQPkgAppWorkflowStep::ensurePage()
 void YQPkgAppWorkflowStep::activate( bool goingForward )
 {
     Q_UNUSED( goingForward );
-    logDebug() << "Activating step " << _id << endl;
+    logDebug() << "Activating step " << _id << Qt::endl;
 
     ensurePage();
     _app->mainWin()->showPage( _page );
@@ -113,12 +113,12 @@ void YQPkgAppWorkflowStep::nextPage( bool goingForward )
 
     if ( goingForward || _app->workflow()->historyEmpty() )
     {
-        logDebug() << "_app->next()" << endl;
+        logDebug() << "_app->next()" << Qt::endl;
         _app->next();
     }
     else
     {
-        logDebug() << "_app->back()" << endl;
+        logDebug() << "_app->back()" << Qt::endl;
         _app->back();
     }
 }
@@ -151,7 +151,7 @@ void YQPkgInitReposStep::initRepos()
     if ( _reposInitialized )
         return;
 
-    logDebug() << "Initializing zypp..." << endl;
+    logDebug() << "Initializing zypp..." << Qt::endl;
 
     YQPkgRepoManager * repoMan = _app->repoManager();
     CHECK_PTR( repoMan );
@@ -174,7 +174,7 @@ void YQPkgInitReposStep::initRepos()
         throw;  // Nothing else that we can do here
     }
 
-    logDebug() << "Initializing zypp done" << endl;
+    logDebug() << "Initializing zypp done" << Qt::endl;
     _reposInitialized = true;
 }
 

--- a/src/YQPkgApplication.cc
+++ b/src/YQPkgApplication.cc
@@ -63,7 +63,7 @@ YQPkgApplication::YQPkgApplication( YQPkgAppOptions optFlags )
         _optFlags |= OptReadOnly;
     }
 
-    logDebug() << "_optFlags: 0x" << hex << _optFlags << dec << Qt::endl;
+    logDebug() << "_optFlags: 0x" << Qt::hex << _optFlags << Qt::dec << Qt::endl;
 
     createMainWin(); // Create this early to get early visual feedback
     logDebug() << "Creating YQPkgApplication done" << Qt::endl;

--- a/src/YQPkgApplication.cc
+++ b/src/YQPkgApplication.cc
@@ -52,27 +52,27 @@ YQPkgApplication::YQPkgApplication( YQPkgAppOptions optFlags )
     , _zyppLogger(0)
     , _pkgTasks(0)
 {
-    logDebug() << "Creating YQPkgApplication" << endl;
+    logDebug() << "Creating YQPkgApplication" << Qt::endl;
 
     _instance = this;
     _optFlags = optFlags;
 
     if ( ! runningAsRoot() )
     {
-        logInfo() << "Not running as root - enforcing read-only mode" << endl;
+        logInfo() << "Not running as root - enforcing read-only mode" << Qt::endl;
         _optFlags |= OptReadOnly;
     }
 
-    logDebug() << "_optFlags: 0x" << hex << _optFlags << dec << endl;
+    logDebug() << "_optFlags: 0x" << hex << _optFlags << dec << Qt::endl;
 
     createMainWin(); // Create this early to get early visual feedback
-    logDebug() << "Creating YQPkgApplication done" << endl;
+    logDebug() << "Creating YQPkgApplication done" << Qt::endl;
 }
 
 
 YQPkgApplication::~YQPkgApplication()
 {
-    logDebug() << "Destroying YQPkgApplication..." << endl;
+    logDebug() << "Destroying YQPkgApplication..." << Qt::endl;
 
     if ( _pkgSel )
         delete _pkgSel;
@@ -100,13 +100,13 @@ YQPkgApplication::~YQPkgApplication()
 
     _instance = 0;
 
-    logDebug() << "Destroying YQPkgApplication done" << endl;
+    logDebug() << "Destroying YQPkgApplication done" << Qt::endl;
 }
 
 
 void YQPkgApplication::run()
 {
-    logDebug() << endl;
+    logDebug() << Qt::endl;
 
     if ( ! _workflow )
         createWorkflow();
@@ -128,12 +128,12 @@ void YQPkgApplication::run()
 
 void YQPkgApplication::createMainWin()
 {
-    logDebug() << endl;
+    logDebug() << Qt::endl;
 
     if ( _mainWin )
         return;
 
-    logDebug() << "Creating the main window" << endl;
+    logDebug() << "Creating the main window" << Qt::endl;
 
     _mainWin = new MainWindow();
     CHECK_NEW( _mainWin );
@@ -149,7 +149,7 @@ void YQPkgApplication::createWorkflow()
     if ( _workflow )
         return;
 
-    logDebug() << "Creating the application workflow" << endl;
+    logDebug() << "Creating the application workflow" << Qt::endl;
 
     WorkflowStepList steps;
     steps << new YQPkgInitReposStep( this, "initRepos" ) // excluded from history
@@ -160,7 +160,7 @@ void YQPkgApplication::createWorkflow()
     _workflow = new Workflow( steps );
     CHECK_PTR( _workflow );
 
-    logDebug() << "Starting workflow" << endl;
+    logDebug() << "Starting workflow" << Qt::endl;
     _workflow->start();
 }
 
@@ -344,21 +344,21 @@ bool YQPkgApplication::eventFilter( QObject * watchedObj, QEvent * event )
 
         if ( currentPage == _pkgSel )
         {
-            logInfo() << "Caught WM_CLOSE for YQPkgSelector" << endl;
+            logInfo() << "Caught WM_CLOSE for YQPkgSelector" << Qt::endl;
             _pkgSel->wmClose();  // _pkgSel handles asking for confirmation etc.
 
             return true;        // Event processing finished for this one
         }
         else if ( currentPage == _pkgCommitPage )
         {
-            logInfo() << "Caught WM_CLOSE for PkgCommitPage" << endl;
+            logInfo() << "Caught WM_CLOSE for PkgCommitPage" << Qt::endl;
             _pkgCommitPage->wmClose();
 
             return true;        // Event processing finished for this one
         }
         else
         {
-            logInfo() << "Caught WM_CLOSE, but not for YQPkgSelector" << endl;
+            logInfo() << "Caught WM_CLOSE, but not for YQPkgSelector" << Qt::endl;
         }
     }
 
@@ -373,7 +373,7 @@ void YQPkgApplication::next()
     if ( ! _workflow )
         return;
 
-    logDebug() << "Current page: " << _workflow->currentStep()->id() << endl;
+    logDebug() << "Current page: " << _workflow->currentStep()->id() << Qt::endl;
 
     if ( _workflow->currentStep()->id() == "pkgCommit" )
     {
@@ -381,7 +381,7 @@ void YQPkgApplication::next()
 
         if ( ! _pkgCommitPage->showSummaryPage() )
         {
-            logInfo() << "Skipping summary page -> quitting" << endl;
+            logInfo() << "Skipping summary page -> quitting" << Qt::endl;
             quit();
 
             return;
@@ -390,12 +390,12 @@ void YQPkgApplication::next()
 
     if ( _workflow->atLastStep() )
     {
-        logDebug() << "This was the last step." << endl;
+        logDebug() << "This was the last step." << Qt::endl;
         finish();
     }
     else
     {
-        logDebug() << "Next step in the workflow." << endl;
+        logDebug() << "Next step in the workflow." << Qt::endl;
         _workflow->next();
     }
 }
@@ -403,14 +403,14 @@ void YQPkgApplication::next()
 
 void YQPkgApplication::finish()
 {
-    logDebug() << "Quitting the program." << endl;
+    logDebug() << "Quitting the program." << Qt::endl;
     quit();
 }
 
 
 void YQPkgApplication::back()
 {
-    logDebug() << endl;
+    logDebug() << Qt::endl;
     CHECK_PTR( _workflow );
 
     if ( ! _workflow )
@@ -422,7 +422,7 @@ void YQPkgApplication::back()
 
 void YQPkgApplication::restart()
 {
-    logDebug() << endl;
+    logDebug() << Qt::endl;
     CHECK_PTR( _workflow );
 
     if ( ! _workflow )
@@ -437,7 +437,7 @@ void YQPkgApplication::skipCommit()
     // The user finished the package selection with "Accept", but there was no
     // change: Skip the "commit" phase and go straight to the summary screen.
 
-    logDebug() << endl;
+    logDebug() << Qt::endl;
     CHECK_PTR( _workflow );
 
     if ( ! _workflow )
@@ -449,7 +449,7 @@ void YQPkgApplication::skipCommit()
 
 void YQPkgApplication::quit( bool askForConfirmation )
 {
-    logDebug() << endl;
+    logDebug() << Qt::endl;
 
     if ( askForConfirmation )
     {

--- a/src/YQPkgChangeLogView.cc
+++ b/src/YQPkgChangeLogView.cc
@@ -48,7 +48,7 @@ YQPkgChangeLogView::showDetails( ZyppSel selectable )
 	return;
     }
 
-    // logVerbose() << "Generating changelog..." << endl;
+    // logVerbose() << "Generating changelog..." << Qt::endl;
 
     QString html = htmlStart();
     html += htmlHeading( selectable, false );
@@ -81,7 +81,7 @@ YQPkgChangeLogView::showDetails( ZyppSel selectable )
 
 QString YQPkgChangeLogView::changeLogTable( const zypp::Changelog & changeLog ) const
 {
-    // logVerbose () << "Changelog size: " << changeLog.size() << " entries" << endl;
+    // logVerbose () << "Changelog size: " << changeLog.size() << " entries" << Qt::endl;
 
     QString html;
     int count = 0;

--- a/src/YQPkgChangesDialog.cc
+++ b/src/YQPkgChangesDialog.cc
@@ -151,7 +151,7 @@ YQPkgChangesDialog::filter( Filters flt )
 void
 YQPkgChangesDialog::slotFilterChanged( int index )
 {
-    logInfo() << "filter index changed to: " << index << endl;
+    logInfo() << "filter index changed to: " << index << Qt::endl;
     QVariant var = _filter->itemData( index );
 
     if ( var.isValid() && var.canConvert<Filters>() )
@@ -161,7 +161,7 @@ YQPkgChangesDialog::slotFilterChanged( int index )
     }
     else
     {
-        logError() << "Can't find filter for index " << index << endl;
+        logError() << "Can't find filter for index " << index << Qt::endl;
     }
 
 }
@@ -177,7 +177,7 @@ YQPkgChangesDialog::setFilter( Filters filters )
 void
 YQPkgChangesDialog::setFilter( const QRegExp & regexp, Filters flt )
 {
-    logInfo() << "filter changed to: " << flt << endl;
+    logInfo() << "filter changed to: " << flt << Qt::endl;
 
     int index = -1;
 
@@ -206,7 +206,7 @@ YQPkgChangesDialog::setFilter( const QRegExp & regexp, Filters flt )
     }
     else
     {
-        logError() << "Can't find index for filter " << flt << endl;
+        logError() << "Can't find index for filter " << flt << Qt::endl;
     }
 }
 
@@ -296,7 +296,7 @@ YQPkgChangesDialog::showChangesDialog( QWidget *        parent,
 
     if ( dialog.isEmpty() && options.testFlag( OptionAutoAcceptIfEmpty ) )
     {
-        logInfo() << "No items to show in changes dialog, accepting it automatically" << endl;
+        logInfo() << "No items to show in changes dialog, accepting it automatically" << Qt::endl;
         return true;
     }
 
@@ -324,7 +324,7 @@ YQPkgChangesDialog::showChangesDialog( QWidget *        parent,
 
     if ( dialog.isEmpty() &&  options.testFlag(OptionAutoAcceptIfEmpty) )
     {
-        logInfo() << "No items to show in dialog, accepting it automatically" << endl;
+        logInfo() << "No items to show in dialog, accepting it automatically" << Qt::endl;
         return true;
     }
 
@@ -369,7 +369,7 @@ YQPkgUnsupportedPackagesDialog::showUnsupportedPackagesDialog( QWidget *       p
 
     if ( dialog.isEmpty() && options.testFlag( OptionAutoAcceptIfEmpty ) )
     {
-        logInfo() << "No items to show in unsupported packages dialog, accepting it automatically" << endl;
+        logInfo() << "No items to show in unsupported packages dialog, accepting it automatically" << Qt::endl;
         return true;
     }
 

--- a/src/YQPkgConflictDialog.cc
+++ b/src/YQPkgConflictDialog.cc
@@ -239,11 +239,11 @@ int
 YQPkgConflictDialog::solveAndShowConflicts()
 {
     prepareSolving();
-    logInfo() << "Resolving dependencies..." << endl;
+    logInfo() << "Resolving dependencies..." << Qt::endl;
 
     bool success = zypp::getZYpp()->resolver()->resolvePool();
 
-    logDebug() << "Resolving dependencies done." << endl;
+    logDebug() << "Resolving dependencies done." << Qt::endl;
 
     return processSolverResult( success );
 }
@@ -259,11 +259,11 @@ YQPkgConflictDialog::verifySystem( bool showBusyPopup)
                                    MainWindow::instance() );
 
     prepareSolving();
-    logInfo() << "Verifying all system dependencies..." << endl;
+    logInfo() << "Verifying all system dependencies..." << Qt::endl;
 
     bool success = zypp::getZYpp()->resolver()->verifySystem();
 
-    logDebug() << "System dependencies verified." << endl;
+    logDebug() << "System dependencies verified." << Qt::endl;
 
     if ( busyPopup )
         delete busyPopup;
@@ -284,12 +284,12 @@ int
 YQPkgConflictDialog::doPackageUpdate()
 {
     prepareSolving();
-    logInfo() << "Starting a global package update ('zypper up' counterpart)..." << endl;
+    logInfo() << "Starting a global package update ('zypper up' counterpart)..." << Qt::endl;
 
     bool success = true;
     zypp::getZYpp()->resolver()->doUpdate(); // No return value, assume success.
 
-    logDebug() << "Package update done." << endl;
+    logDebug() << "Package update done." << Qt::endl;
 
     return processSolverResult( success );
 }
@@ -299,11 +299,11 @@ int
 YQPkgConflictDialog::doDistUpgrade()
 {
     prepareSolving();
-    logInfo() << "Starting a dist upgrade ('zypper dup' counterpart)" << endl;
+    logInfo() << "Starting a dist upgrade ('zypper dup' counterpart)" << Qt::endl;
 
     bool success = zypp::getZYpp()->resolver()->doUpgrade();
 
-    logDebug() << "Dist upgrade done." << endl;
+    logDebug() << "Dist upgrade done." << Qt::endl;
 
     return processSolverResult( success );
 }
@@ -368,7 +368,7 @@ YQPkgConflictDialog::processSolverResult( bool success )
     }
     else                // There were solving problems.
     {
-        logDebug() << "Dependency conflict!" << endl;
+        logDebug() << "Dependency conflict!" << Qt::endl;
         busyCursor();
 
         _conflictList->fill( zypp::getZYpp()->resolver()->problems() );
@@ -425,11 +425,11 @@ YQPkgConflictDialog::askCreateSolverTestCase()
     if ( button_no == 1 )  // Cancel
         return;
 
-    logInfo() << "Generating solver test case START" << endl;
+    logInfo() << "Generating solver test case START" << Qt::endl;
 
     bool success = zypp::getZYpp()->resolver()->createSolverTestcase( qPrintable( testCaseDir ) );
 
-    logInfo() << "Generating solver test case END" << endl;
+    logInfo() << "Generating solver test case END" << Qt::endl;
 
     if ( success )
     {

--- a/src/YQPkgConflictList.cc
+++ b/src/YQPkgConflictList.cc
@@ -158,7 +158,7 @@ YQPkgConflictList::saveToFile( const QString filename, bool interactive ) const
 
     if ( ! file.open(QIODevice::WriteOnly) )
     {
-        logError() << "Can't open file " << filename << endl;
+        logError() << "Can't open file " << filename << Qt::endl;
 
         if ( interactive )
         {
@@ -347,7 +347,7 @@ YQPkgConflict::userSelectedResolution()
         if ( button->isChecked() )
         {
             ZyppSolution solution = it.value();
-            logInfo() << "User selected resolution \"" << solution->description() << "\"" << endl;
+            logInfo() << "User selected resolution \"" << solution->description() << "\"" << Qt::endl;
 
             return solution;
         }

--- a/src/YQPkgDescriptionView.cc
+++ b/src/YQPkgDescriptionView.cc
@@ -192,13 +192,13 @@ YQPkgDescriptionView::showLink( const QUrl & url )
     if ( url.scheme() == "pkg" )
     {
         QString pkgName = url.authority();
-        logInfo() << "Hyperlinking to package \"" << pkgName << "\"" << endl;
+        logInfo() << "Hyperlinking to package \"" << pkgName << "\"" << Qt::endl;
         YQPkgDescriptionDialog::showDescriptionDialog( pkgName );
     }
     else
     {
         logError() << "Protocol not supported - can't follow hyperlink \""
-                   << url.toString() << "\"" << endl;
+                   << url.toString() << "\"" << Qt::endl;
     }
 }
 

--- a/src/YQPkgDiskUsageList.cc
+++ b/src/YQPkgDiskUsageList.cc
@@ -117,7 +117,7 @@ YQPkgDiskUsageList::updateDiskUsage()
         if ( item )
             item->updateDuData( partitionDu );
         else
-            logError() << "No entry for mount point " << partitionDu.dir << endl;
+            logError() << "No entry for mount point " << partitionDu.dir << Qt::endl;
     }
 
     resizeColumnToContents( totalSizeCol() );
@@ -178,7 +178,7 @@ YQPkgDiskUsageList::keyPressEvent( QKeyEvent * event )
             if ( event->key() == Qt::Key_Q )
             {
                 _debug = ! _debug;
-                logInfo() << "Debug mode: " << _debug << endl;
+                logInfo() << "Debug mode: " << _debug << Qt::endl;
             }
 
         }
@@ -251,7 +251,7 @@ YQPkgDiskUsageListItem::YQPkgDiskUsageListItem( YQPkgDiskUsageList *    parent,
     , _partitionDu( partitionDu )
     , _pkgDiskUsageList( parent )
 {
-    // logVerbose() << "disk usage list entry for " << partitionDu.dir << endl;
+    // logVerbose() << "disk usage list entry for " << partitionDu.dir << Qt::endl;
 }
 
 
@@ -301,7 +301,7 @@ YQPkgDiskUsageListItem::checkRemainingDiskSpace()
                << " free percent: " << percent << "%, "
                << " bfree: " << freeSize()
                << " (" << free << "MiB)"
-               << endl;
+               << Qt::endl;
 #endif
 
     if ( percent > MIN_PERCENT_WARN )

--- a/src/YQPkgFilterTab.cc
+++ b/src/YQPkgFilterTab.cc
@@ -288,7 +288,7 @@ YQPkgFilterTab::showPage( const QString & internalName )
     if ( page )
         showPage( page );
     else
-        logWarning() << "No page with ID \"" << internalName << "\"" << endl;
+        logWarning() << "No page with ID \"" << internalName << "\"" << Qt::endl;
 }
 
 
@@ -629,8 +629,8 @@ YQPkgFilterTab::readSettings()
     settings.endGroup();
 
 
-    logDebug() << "Restoring pages " << pages << endl;
-    logDebug() << "Current page: " << current << endl;
+    logDebug() << "Restoring pages " << pages << Qt::endl;
+    logDebug() << "Current page: " << current << Qt::endl;
 
     foreach ( QString id, pages )
     {
@@ -639,7 +639,7 @@ YQPkgFilterTab::readSettings()
         if ( page )
             showPage( page );
         else
-            logWarning() << "No page with ID \"" << id << "\"" << endl;
+            logWarning() << "No page with ID \"" << id << "\"" << Qt::endl;
     }
 
     if ( ! current.isEmpty() )
@@ -649,7 +649,7 @@ YQPkgFilterTab::readSettings()
         if ( page )
             showPage( page );
         else
-            logWarning() << "Can't restore current page with ID \"" << current << "\"" << endl;
+            logWarning() << "Can't restore current page with ID \"" << current << "\"" << Qt::endl;
     }
 }
 
@@ -666,7 +666,7 @@ YQPkgFilterTab::writeSettings()
         if ( page )
         {
             if ( page->id.isEmpty() )
-                logWarning() << "No ID for tab page \"" << page->label << "\"" << endl;
+                logWarning() << "No ID for tab page \"" << page->label << "\"" << Qt::endl;
             else
                 pages << page->id;
         }

--- a/src/YQPkgFilters.cc
+++ b/src/YQPkgFilters.cc
@@ -43,7 +43,7 @@ YQPkgFilters::singleProductFilter(std::function<bool( const zypp::PoolItem & ite
 
     if ( it == product_end )
     {
-        // logDebug() << "No product found " << endl;
+        // logDebug() << "No product found " << Qt::endl;
         return product;
     }
 
@@ -57,13 +57,13 @@ YQPkgFilters::singleProductFilter(std::function<bool( const zypp::PoolItem & ite
 
     if ( it == product_end )
     {
-        logInfo() << "Found single product " << product->name() << endl;
+        logInfo() << "Found single product " << product->name() << Qt::endl;
 
         return product;
     }
 
     product = zypp::asKind<zypp::Product>( it->resolvable() );
-    // logVerbose() << "Found another product " << product->name() << endl;
+    // logVerbose() << "Found another product " << product->name() << Qt::endl;
 
     return ZyppProduct(); // NULL pointer
 }

--- a/src/YQPkgGenericDetailsView.cc
+++ b/src/YQPkgGenericDetailsView.cc
@@ -163,7 +163,7 @@ QString
 YQPkgGenericDetailsView::htmlEscape( const QString & plainText )
 {
     QString html = plainText;
-    // logDebug() << "Escaping \"" << plainText << "\"" << endl;
+    // logDebug() << "Escaping \"" << plainText << "\"" << Qt::endl;
 
     html.replace( QRegExp( "&" ), "&amp;" );
     html.replace( QRegExp( "<" ), "&lt;"  );

--- a/src/YQPkgHistoryDialog.cc
+++ b/src/YQPkgHistoryDialog.cc
@@ -166,7 +166,7 @@ YQPkgHistoryDialog::populate()
     }
     catch (  const zypp::Exception & exception )
     {
-        logWarning() << "CAUGHT zypp exception: " << exception.asUserHistory() << endl;
+        logWarning() << "CAUGHT zypp exception: " << exception.asUserHistory() << Qt::endl;
         showReadHistoryWarning( fromUTF8( exception.asUserHistory() ) );
     }
 }

--- a/src/YQPkgLangList.cc
+++ b/src/YQPkgLangList.cc
@@ -31,7 +31,7 @@ YQPkgLangList::YQPkgLangList( QWidget * parent )
     // FIXME: The base class works with zypp::Resolvable, but zypp::Locale
     // isn't one any longer!
 
-    logVerbose() << "Creating language list" << endl;
+    logVerbose() << "Creating language list" << Qt::endl;
 
     // Translators: Table column heading for a language ISO code like "de_DE",
     // "en_US". Please keep this short to avoid stretching the column too wide!
@@ -66,7 +66,7 @@ YQPkgLangList::YQPkgLangList( QWidget * parent )
     selectSomething();
     resizeColumnToContents(_statusCol);
 
-    logVerbose() << "Creating language list done" << endl;
+    logVerbose() << "Creating language list done" << Qt::endl;
 }
 
 
@@ -80,7 +80,7 @@ void
 YQPkgLangList::fillList()
 {
     clear();
-    // logVerbose() << "Filling language list" << endl;
+    // logVerbose() << "Filling language list" << Qt::endl;
 
     zypp::LocaleSet locales = zypp::getZYpp()->pool().getAvailableLocales();
 
@@ -91,7 +91,7 @@ YQPkgLangList::fillList()
         addLangItem( *it );
     }
 
-    // logVerbose() << "Language list filled" << endl;
+    // logVerbose() << "Language list filled" << Qt::endl;
 }
 
 

--- a/src/YQPkgList.cc
+++ b/src/YQPkgList.cc
@@ -123,7 +123,7 @@ YQPkgList::addPkgItem( ZyppSel  selectable,
 
     if ( ! selectable )
     {
-        logError() << "NULL zypp::ui::Selectable!" << endl;
+        logError() << "NULL zypp::ui::Selectable!" << Qt::endl;
         return;
     }
 
@@ -498,7 +498,7 @@ YQPkgList::globalSetPkgStatus( ZyppStatus newStatus, bool force, bool countOnly 
                     selectable->setStatus( newStatus );
 
                 changedCount++;
-                // logInfo() << "Updating " << selectable->name() << endl;
+                // logInfo() << "Updating " << selectable->name() << Qt::endl;
             }
         }
     }

--- a/src/YQPkgObjList.cc
+++ b/src/YQPkgObjList.cc
@@ -109,7 +109,7 @@ YQPkgObjList::addPkgObjItem( ZyppSel selectable, ZyppObj zyppObj )
 {
     if ( ! selectable )
     {
-        logError() << "Null zypp::ui::Selectable!" << endl;
+        logError() << "Null zypp::ui::Selectable!" << Qt::endl;
         return;
     }
 
@@ -148,7 +148,7 @@ YQPkgObjList::pkgObjClicked( int               button,
 
     if ( item )
     {
-        // logDebug() << "CLICKED: %s", item->zyppObj()->name().c_str()) << endl;
+        // logDebug() << "CLICKED: %s", item->zyppObj()->name().c_str()) << Qt::endl;
 
         if ( button == Qt::LeftButton )
         {
@@ -186,7 +186,7 @@ YQPkgObjList::clear()
 void
 YQPkgObjList::resetContent()
 {
-    logDebug() << endl;
+    logDebug() << Qt::endl;
     clear();
 }
 
@@ -701,7 +701,7 @@ void
 YQPkgObjList::applyExcludeRules()
 {
     _excludedItemsCount = 0;
-    // logDebug() << "Applying exclude rules" << endl;
+    // logDebug() << "Applying exclude rules" << Qt::endl;
     QTreeWidgetItemIterator listView_it( this );
 
     while ( *listView_it )
@@ -724,7 +724,7 @@ YQPkgObjList::logExcludeStatistics()
 {
     if ( _excludedItemsCount > 0 )
     {
-        logVerbose() << _excludedItemsCount << " packages excluded" << endl;
+        logVerbose() << _excludedItemsCount << " packages excluded" << Qt::endl;
 
         for ( ExcludeRuleList::iterator rule_it = _excludeRules.begin();
               rule_it != _excludeRules.end();
@@ -736,7 +736,7 @@ YQPkgObjList::logExcludeStatistics()
             {
                 logDebug() << "Active exclude rule: \""
                            << rule->regexp().pattern() << "\""
-                           << endl;
+                           << Qt::endl;
             }
         }
     }
@@ -782,11 +782,11 @@ YQPkgObjList::applyExcludeRules( QTreeWidgetItem * listViewItem )
             {
                 logDebug() << "Rule \"" << matchingRule->regexp().pattern()
                            << "\" matches: Excluding " << item->zyppObj()->name()
-                           << endl;
+                           << Qt::endl;
             }
             else
             {
-                logDebug() << "Un-excluding " << item->zyppObj()->name() << endl;
+                logDebug() << "Un-excluding " << item->zyppObj()->name() << Qt::endl;
             }
 #endif
         }
@@ -1030,7 +1030,7 @@ YQPkgObjListItem::status() const
 {
     if ( ! selectable() )
     {
-        logError() << "No selectable" << endl;
+        logError() << "No selectable" << Qt::endl;
         return S_NoInst;
     }
 
@@ -1144,7 +1144,7 @@ YQPkgObjListItem::cycleStatus()
             }
             else
             {
-                logWarning() << "No candidate for " << selectable()->theObj()->name() << endl;
+                logWarning() << "No candidate for " << selectable()->theObj()->name() << Qt::endl;
                 newStatus = S_NoInst;
             }
             break;
@@ -1203,7 +1203,7 @@ YQPkgObjListItem::showNotifyTexts( ZyppStatus status )
 
     if ( ! text.empty() )
     {
-        logDebug() << "Showing notify text" << endl;
+        logDebug() << "Showing notify text" << Qt::endl;
         YQPkgTextDialog::showText( _pkgObjList, selectable(), text );
     }
 }
@@ -1247,14 +1247,14 @@ YQPkgObjListItem::showLicenseAgreement( ZyppSel sel )
     if ( licenseText.empty() )
         return true;
 
-    logDebug() << "Showing license agreement for " << sel->name() << endl;
+    logDebug() << "Showing license agreement for " << sel->name() << Qt::endl;
 
     bool confirmed = YQPkgTextDialog::confirmText( 0, // parent
                                                    sel, licenseText );
 
     if ( confirmed )
     {
-        logInfo() << "User confirmed license agreement for " << sel->name() << endl;
+        logInfo() << "User confirmed license agreement for " << sel->name() << Qt::endl;
         sel->setLicenceConfirmed( true );
     }
     else
@@ -1269,7 +1269,7 @@ YQPkgObjListItem::showLicenseAgreement( ZyppSel sel )
 
                 logWarning() << "User rejected license agreement for " << sel->name()
                              << " - setting to TABOO"
-                             << endl;
+                             << Qt::endl;
 
                 sel->setStatus( S_Taboo );
                 break;
@@ -1280,7 +1280,7 @@ YQPkgObjListItem::showLicenseAgreement( ZyppSel sel )
 
                 logWarning() << "User rejected license agreement for " << sel->name()
                              << "  - setting to PROTECTED"
-                             << endl;
+                             << Qt::endl;
 
                 sel->setStatus( S_Protected );
                 // S_Keep wouldn't be good enough: The next solver run might
@@ -1432,7 +1432,7 @@ YQPkgObjList::ExcludeRule::enable( bool enable )
 #if VERBOSE_EXCLUDE_RULES
     logDebug() << ( enable ? "Enabling" : "Disabling" )
                << " exclude rule " << _regexp.pattern()
-               << endl;
+               << Qt::endl;
 #endif
 }
 

--- a/src/YQPkgPatchList.cc
+++ b/src/YQPkgPatchList.cc
@@ -45,7 +45,7 @@ using std::set;
 YQPkgPatchList::YQPkgPatchList( QWidget * parent )
     : YQPkgObjList( parent )
 {
-    logDebug() << "Creating patch list" << endl;
+    logDebug() << "Creating patch list" << Qt::endl;
 
     _filterCriteria = RelevantPatches;
 
@@ -72,7 +72,7 @@ YQPkgPatchList::YQPkgPatchList( QWidget * parent )
 
     fillList();
 
-    logDebug() << "Creating patch list done" << endl;
+    logDebug() << "Creating patch list done" << Qt::endl;
 }
 
 
@@ -103,7 +103,7 @@ YQPkgPatchList::category( YQPkgPatchCategory category )
     if ( ! cat )
     {
 #if VERBOSE_PATCHES
-        logDebug() << "New patch category \""<< category << "\"" << endl;
+        logDebug() << "New patch category \""<< category << "\"" << Qt::endl;
 #endif
 
         cat = new YQPkgPatchCategoryItem( category, this );
@@ -130,7 +130,7 @@ YQPkgPatchList::fillList()
     _categories.clear();
 
     clear();
-    // logDebug() << "Filling patch list" << endl;
+    // logDebug() << "Filling patch list" << Qt::endl;
 
     for ( ZyppPoolIterator it = zyppPatchesBegin();
           it != zyppPatchesEnd();
@@ -179,7 +179,7 @@ YQPkgPatchList::fillList()
                     break;
 
                 default:
-                    logDebug() << "unknown patch filter" << endl;
+                    logDebug() << "unknown patch filter" << Qt::endl;
                     break;
 
             }
@@ -189,19 +189,19 @@ YQPkgPatchList::fillList()
 #if VERBOSE_PATCHES
                 logDebug() << "Displaying patch " << zyppPatch->name()
                            << " - " <<  zyppPatch->summary()
-                           << endl;
+                           << Qt::endl;
 #endif
                 addPatchItem( *it, zyppPatch);
             }
         }
         else
         {
-            logError() << "Found non-patch selectable" << endl;
+            logError() << "Found non-patch selectable" << Qt::endl;
         }
     }
 
 #if VERBOSE_PATCHES
-    logDebug() << "Patch list filled" << endl;
+    logDebug() << "Patch list filled" << Qt::endl;
 #endif
 
     resizeColumnToContents( _statusCol );
@@ -254,12 +254,12 @@ YQPkgPatchList::filter()
         }
         else
         {
-            logInfo() << "patch is bogus" << endl;
+            logInfo() << "patch is bogus" << Qt::endl;
         }
 
     }
     else
-        logWarning() << "selection empty" << endl;
+        logWarning() << "selection empty" << Qt::endl;
 
     emit filterFinished();
 }
@@ -271,7 +271,7 @@ YQPkgPatchList::addPatchItem( ZyppSel   selectable,
 {
     if ( ! selectable || ! zyppPatch )
     {
-        logError() << "NULL ZyppSel!" << endl;
+        logError() << "NULL ZyppSel!" << Qt::endl;
         return;
     }
 
@@ -375,7 +375,7 @@ YQPkgPatchList::keyPressEvent( QKeyEvent * event )
 
                 if ( item && item->selectable()->hasInstalledObj() )
                 {
-                    logWarning() << "Deleting patches is not supported" << endl;
+                    logWarning() << "Deleting patches is not supported" << Qt::endl;
                     return;
                 }
             }
@@ -528,7 +528,7 @@ YQPkgPatchCategoryItem::patchCategory( const QString & cat )
     if ( category == "optional"    ) return YQPkgOptionalPatch;
     if ( category == "document"    ) return YQPkgDocumentPatch;
 
-    logWarning() << "Unknown patch category \"" << category << "\"" << endl;
+    logWarning() << "Unknown patch category \"" << category << "\"" << Qt::endl;
 
     return YQPkgOptionalPatch;
 }

--- a/src/YQPkgPatternList.cc
+++ b/src/YQPkgPatternList.cc
@@ -43,7 +43,7 @@ YQPkgPatternList::YQPkgPatternList( QWidget * parent,
     : YQPkgObjList( parent )
     , _orderCol( -1 )
 {
-    logDebug() << "Creating pattern list" << endl;
+    logDebug() << "Creating pattern list" << Qt::endl;
 
     // Translators: "Pattern" refers to so-called "software patterns",
     // i.e., specific task-oriented groups of packages, like "everything that
@@ -113,7 +113,7 @@ YQPkgPatternList::YQPkgPatternList( QWidget * parent,
 #endif
     }
 
-    logDebug() << "Creating pattern list done" << endl;
+    logDebug() << "Creating pattern list done" << Qt::endl;
 }
 
 
@@ -129,7 +129,7 @@ YQPkgPatternList::fillList()
     _categories.clear();
 
     clear();
-    logDebug() << "Filling pattern list" << endl;
+    logDebug() << "Filling pattern list" << Qt::endl;
 
     for ( ZyppPoolIterator it = zyppPatternsBegin();
           it != zyppPatternsEnd();
@@ -146,18 +146,18 @@ YQPkgPatternList::fillList()
 #if VERBOSE_PATTERN_LIST
             else
                 logDebug() << "Pattern " << zyppPattern->name()
-                           << " is not user-visible" << endl;
+                           << " is not user-visible" << Qt::endl;
 #endif
         }
         else
         {
-            logError() << "Found non-Pattern selectable" << endl;
+            logError() << "Found non-Pattern selectable" << Qt::endl;
         }
     }
 
 
 #if VERBOSE_PATTERN_LIST
-    logDebug() << "Pattern list filled" << endl;
+    logDebug() << "Pattern list filled" << Qt::endl;
 #endif
 
     resizeColumnToContents( _iconCol   );
@@ -176,7 +176,7 @@ YQPkgPatternList::category( const QString & categoryName )
     if ( ! cat )
     {
 #if VERBOSE_PATTERN_LIST
-        logDebug() << "New pattern category \""<< categoryName << "\"" << endl;
+        logDebug() << "New pattern category \""<< categoryName << "\"" << Qt::endl;
 #endif
 
         cat = new YQPkgPatternCategoryItem( this, categoryName );
@@ -245,7 +245,7 @@ YQPkgPatternList::addPatternItem( ZyppSel     selectable,
 {
     if ( ! selectable )
     {
-        logError() << "NULL ZyppSelectable!" << endl;
+        logError() << "NULL ZyppSelectable!" << Qt::endl;
         return;
     }
 

--- a/src/YQPkgProductList.cc
+++ b/src/YQPkgProductList.cc
@@ -31,7 +31,7 @@ YQPkgProductList::YQPkgProductList( QWidget * parent )
     : YQPkgObjList( parent )
     , _vendorCol( -42 )
 {
-    logDebug() << "Creating product list" << endl;
+    logDebug() << "Creating product list" << Qt::endl;
 
     QStringList headers;
     int numCol = 0;
@@ -52,7 +52,7 @@ YQPkgProductList::YQPkgProductList( QWidget * parent )
     fillList();
     selectSomething();
 
-    logDebug() << "Creating product list done" << endl;
+    logDebug() << "Creating product list done" << Qt::endl;
 }
 
 
@@ -66,7 +66,7 @@ void
 YQPkgProductList::fillList()
 {
     clear();
-    // logVerbose() << "Filling product list" << endl;
+    // logVerbose() << "Filling product list" << Qt::endl;
 
     for ( ZyppPoolIterator it = zyppProductsBegin();
           it != zyppProductsEnd();
@@ -80,11 +80,11 @@ YQPkgProductList::fillList()
         }
         else
         {
-            logError() << "Found non-product selectable" << endl;
+            logError() << "Found non-product selectable" << Qt::endl;
         }
     }
 
-    // logVerbose() << "product list filled" << endl;
+    // logVerbose() << "product list filled" << Qt::endl;
     resizeColumnToContents( _statusCol );
 }
 
@@ -95,7 +95,7 @@ YQPkgProductList::addProductItem( ZyppSel     selectable,
 {
     if ( ! selectable )
     {
-        logError() << "NULL ZyppSel!" << endl;
+        logError() << "NULL ZyppSel!" << Qt::endl;
         return;
     }
 

--- a/src/YQPkgRepoList.cc
+++ b/src/YQPkgRepoList.cc
@@ -37,7 +37,7 @@ using std::string;
 YQPkgRepoList::YQPkgRepoList( QWidget * parent )
     : QY2ListView( parent )
 {
-    // logVerbose() << "Creating repository list" << endl;
+    // logVerbose() << "Creating repository list" << Qt::endl;
 
     _nameCol = -1;
 
@@ -76,7 +76,7 @@ YQPkgRepoList::YQPkgRepoList( QWidget * parent )
     selectSomething();
 #endif
 
-    // logVerbose() << "Creating repository list done" << endl;
+    // logVerbose() << "Creating repository list done" << Qt::endl;
 }
 
 

--- a/src/YQPkgRepoManager.cc
+++ b/src/YQPkgRepoManager.cc
@@ -28,42 +28,42 @@
 
 YQPkgRepoManager::YQPkgRepoManager()
 {
-    logDebug() << "Creating YQPkgRepoManager" << endl;
+    logDebug() << "Creating YQPkgRepoManager" << Qt::endl;
 }
 
 
 YQPkgRepoManager::~YQPkgRepoManager()
 {
-    logDebug() << "Destroying YQPkgRepoManager..." << endl;
+    logDebug() << "Destroying YQPkgRepoManager..." << Qt::endl;
 
     shutdownZypp();
 
-    logDebug() << "Destroying YQPkgRepoManager done" << endl;
+    logDebug() << "Destroying YQPkgRepoManager done" << Qt::endl;
 }
 
 
 void YQPkgRepoManager::initTarget()
 {
-    logDebug() << "Creating the ZyppLogger" << endl;
+    logDebug() << "Creating the ZyppLogger" << Qt::endl;
     YQPkgApplication::instance()->createZyppLogger();
 
-    logDebug() << "Initializing zypp..." << endl;
+    logDebug() << "Initializing zypp..." << Qt::endl;
 
     zyppPtr()->initializeTarget( "/", false );  // don't rebuild rpmdb
     zyppPtr()->target()->load(); // Load pkgs from the target (rpmdb)
 
-    logDebug() << "Initializing zypp done" << endl;
+    logDebug() << "Initializing zypp done" << Qt::endl;
 }
 
 
 void YQPkgRepoManager::shutdownZypp()
 {
-    logDebug() << "Shutting down zypp..." << endl;
+    logDebug() << "Shutting down zypp..." << Qt::endl;
 
     _repo_manager_ptr.reset();  // deletes the RepoManager
     _zypp_ptr.reset();          // deletes the ZYpp instance
 
-    logDebug() << "Shutting down zypp done" << endl;
+    logDebug() << "Shutting down zypp done" << Qt::endl;
 }
 
 
@@ -82,7 +82,7 @@ YQPkgRepoManager::repoManager()
 {
     if ( ! _repo_manager_ptr )
     {
-        logDebug() << "Creating RepoManager" << endl;
+        logDebug() << "Creating RepoManager" << Qt::endl;
         _repo_manager_ptr.reset( new zypp::RepoManager() );
     }
 
@@ -110,7 +110,7 @@ YQPkgRepoManager::zyppConnectInternal( int attempts, int waitSeconds )
     {
 	try
 	{
-	    logInfo() << "Initializing Zypp library..." << endl;
+	    logInfo() << "Initializing Zypp library..." << Qt::endl;
 	    _zypp_ptr = zypp::getZYpp();
 
  	    // initialize solver flag, be compatible with zypper
@@ -165,12 +165,12 @@ void YQPkgRepoManager::findEnabledRepos()
 
             logInfo() << "Found repo \"" << repo.name() << "\""
                       << " URL: " << repo.url().asString()
-                      << endl;
+                      << Qt::endl;
         }
         else
         {
             logInfo() << "Ignoring disabled repo \"" << repo.name() << "\""
-                      << endl;
+                      << Qt::endl;
         }
     }
 }
@@ -180,7 +180,7 @@ void YQPkgRepoManager::refreshRepos()
 {
     if ( geteuid() != 0 )
     {
-        logWarning() << "Skipping repos refresh for non-root user" << endl;
+        logWarning() << "Skipping repos refresh for non-root user" << Qt::endl;
         return;
     }
 
@@ -192,7 +192,7 @@ void YQPkgRepoManager::loadRepos()
 {
     for ( const zypp::RepoInfo & repo: _repos )
     {
-        logDebug() << "Loading resolvables from " << repo.name() << endl;
+        logDebug() << "Loading resolvables from " << repo.name() << Qt::endl;
 
         // TO DO: progress callbacks
 	repoManager()->loadFromCache( repo );

--- a/src/YQPkgSearchFilterView.cc
+++ b/src/YQPkgSearchFilterView.cc
@@ -249,7 +249,7 @@ YQPkgSearchFilterView::filter()
                     logError() << "Unexpected search mode "
                                << SearchFilter::toString( searchFilter.filterMode() )
                                << " - falling back to 'Contains'"
-                               << endl;
+                               << Qt::endl;
                     query.setMatchSubstring();
                     break;
             }
@@ -305,7 +305,7 @@ YQPkgSearchFilterView::filter()
     }
     catch ( const std::exception & exception )
     {
-        logWarning() << "CAUGHT zypp exception: " << exception.what() << endl;
+        logWarning() << "CAUGHT zypp exception: " << exception.what() << Qt::endl;
 
         QMessageBox msgBox;
 

--- a/src/YQPkgSelMapper.cc
+++ b/src/YQPkgSelMapper.cc
@@ -28,7 +28,7 @@ YQPkgSelMapper::Cache YQPkgSelMapper::_cache;
 
 YQPkgSelMapper::YQPkgSelMapper()
 {
-    logDebug() << "Creating YQPkgSelMapper; refCount: " << _refCount + 1 << endl;
+    logDebug() << "Creating YQPkgSelMapper; refCount: " << _refCount + 1 << Qt::endl;
 
     if ( ++_refCount == 1 )
         rebuildCache();
@@ -39,18 +39,18 @@ YQPkgSelMapper::~YQPkgSelMapper()
 {
     if ( --_refCount == 0 )
     {
-        logDebug() << "Destroying pkg -> selectable cache"  << endl;
+        logDebug() << "Destroying pkg -> selectable cache"  << Qt::endl;
         _cache.clear();
     }
 
-    logDebug() << "Destroying YQPkgSelMapper done." << endl;
+    logDebug() << "Destroying YQPkgSelMapper done." << Qt::endl;
 }
 
 
 void YQPkgSelMapper::rebuildCache()
 {
     _cache.clear();
-    logDebug() << "Building pkg -> selectable cache" << endl;
+    logDebug() << "Building pkg -> selectable cache" << Qt::endl;
 
     for ( ZyppPoolIterator sel_it = zyppPkgBegin();
           sel_it != zyppPkgEnd();
@@ -82,7 +82,7 @@ void YQPkgSelMapper::rebuildCache()
         }
     }
 
-    logDebug() << "Building pkg -> selectable cache done" << endl;
+    logDebug() << "Building pkg -> selectable cache done" << Qt::endl;
 }
 
 
@@ -99,7 +99,7 @@ YQPkgSelMapper::findZyppSel( ZyppPkg pkg )
     else
     {
 #if VERBOSE_MAPPER
-        logInfo() << "No selectable found for package " << pkg->name() << endl;
+        logInfo() << "No selectable found for package " << pkg->name() << Qt::endl;
 #endif
     }
 

--- a/src/YQPkgSelector.cc
+++ b/src/YQPkgSelector.cc
@@ -141,10 +141,10 @@ YQPkgSelector::YQPkgSelector( QWidget * parent,
     _excludeDevelPkgs            = 0;
     _excludeDebugInfoPkgs        = 0;
 
-    logDebug() << "Creating YQPkgSelector..." << endl;
+    logDebug() << "Creating YQPkgSelector..." << Qt::endl;
 
-    if ( onlineUpdateMode() )   logInfo() << "Online update mode" << endl;
-    if ( updateMode() )         logInfo() << "Update mode" << endl;
+    if ( onlineUpdateMode() )   logInfo() << "Online update mode" << Qt::endl;
+    if ( updateMode() )         logInfo() << "Update mode" << Qt::endl;
 
     basicLayout();
     addMenus();         // Only after all widgets are created!
@@ -160,7 +160,7 @@ YQPkgSelector::YQPkgSelector( QWidget * parent,
 
     if ( ! pagesRestored )
     {
-        logDebug() << "No page configuration saved, using fallbacks" << endl;
+        logDebug() << "No page configuration saved, using fallbacks" << Qt::endl;
 
         //
         // Add a number of default tabs in the desired order
@@ -207,7 +207,7 @@ YQPkgSelector::YQPkgSelector( QWidget * parent,
             // installed, switch to that filter view and show those packages.
             // This should happen only very, very rarely.
 
-            logInfo() << "Found installed retracted packages; switching to that view" << endl;
+            logInfo() << "Found installed retracted packages; switching to that view" << Qt::endl;
             _filters->showPage( _pkgClassificationFilterView );
             _pkgClassificationFilterView->showPkgClass( YQPkgClassRetractedInstalled );
 
@@ -260,17 +260,17 @@ YQPkgSelector::YQPkgSelector( QWidget * parent,
     }
 #endif
 
-    logDebug() << "YQPkgSelector init done" << endl;
+    logDebug() << "YQPkgSelector init done" << Qt::endl;
 }
 
 
 YQPkgSelector::~YQPkgSelector()
 {
-    logDebug() << "Destroying YQPkgSelector..." << endl;
+    logDebug() << "Destroying YQPkgSelector..." << Qt::endl;
 
     writeSettings();
 
-    logDebug() << "Destroying YQPkgSelector done." << endl;
+    logDebug() << "Destroying YQPkgSelector done." << Qt::endl;
 }
 
 
@@ -1136,7 +1136,7 @@ YQPkgSelector::manualResolvePackageDependencies()
 {
     if ( ! _pkgConflictDialog )
     {
-        logError() << "No package conflict dialog existing" << endl;
+        logError() << "No package conflict dialog existing" << Qt::endl;
         return QDialog::Accepted;
     }
 
@@ -1180,7 +1180,7 @@ YQPkgSelector::hotkeyInsertPatchFilterView()
 {
     if ( ! _patchFilterView )
     {
-        logInfo() << "Activating patches filter view" << endl;
+        logInfo() << "Activating patches filter view" << Qt::endl;
 
         addPatchFilterView();
         connectPatchList();
@@ -1258,11 +1258,11 @@ YQPkgSelector::pkgExport()
             exportFile.exceptions( std::ios_base::badbit | std::ios_base::failbit );
             exportFile << writer;
 
-            logInfo() << "Package list exported to " << filename << endl;
+            logInfo() << "Package list exported to " << filename << Qt::endl;
         }
         catch ( std::exception & exception )
         {
-            logWarning() << "Error exporting package list to " << filename << endl;
+            logWarning() << "Error exporting package list to " << filename << Qt::endl;
 
             // The export might have left over a partially written file.
             // Try to delete it. Don't care if it doesn't exist and unlink() fails.
@@ -1289,7 +1289,7 @@ YQPkgSelector::pkgImport()
 
     if ( ! filename.isEmpty() )
     {
-        logInfo() << "Importing package list from " << filename << endl;
+        logInfo() << "Importing package list from " << filename << Qt::endl;
 
         try
         {
@@ -1319,7 +1319,7 @@ YQPkgSelector::pkgImport()
             logDebug() << "Found "        << importPkg.size()
                        <<" packages and " << importPatterns.size()
                        << " patterns in " << filename
-                       << endl;
+                       << Qt::endl;
 
 
             //
@@ -1360,7 +1360,7 @@ YQPkgSelector::pkgImport()
         }
         catch ( const zypp::Exception & exception )
         {
-            logWarning() << "Error reading package list from " << filename << endl;
+            logWarning() << "Error reading package list from " << filename << Qt::endl;
 
             // Post error popup
             QMessageBox::warning( this,                                         // parent
@@ -1402,7 +1402,7 @@ YQPkgSelector::importSelectable( ZyppSel             selectable,
             case S_Del:
             case S_AutoDel:
                 newStatus = S_KeepInstalled;
-                logDebug() << "Keeping " << kind << " " << selectable->name() << endl;
+                logDebug() << "Keeping " << kind << " " << selectable->name() << Qt::endl;
                 break;
 
             case S_NoInst:
@@ -1411,12 +1411,12 @@ YQPkgSelector::importSelectable( ZyppSel             selectable,
                 if ( selectable->hasCandidateObj() )
                 {
                     newStatus = S_Install;
-                    logDebug() << "Adding " << kind << " " <<  selectable->name() << endl;
+                    logDebug() << "Adding " << kind << " " <<  selectable->name() << Qt::endl;
                 }
                 else
                 {
                     logDebug() << "Can't add " << kind << " " << selectable->name()
-                               << ": No candidate" << endl;
+                               << ": No candidate" << Qt::endl;
                 }
                 break;
         }
@@ -1436,7 +1436,7 @@ YQPkgSelector::importSelectable( ZyppSel             selectable,
             case S_Update:
             case S_AutoUpdate:
                 newStatus = S_Del;
-                logDebug() << "Deleting " << kind << " " << selectable->name() << endl;
+                logDebug() << "Deleting " << kind << " " << selectable->name() << Qt::endl;
                 break;
 
             case S_Del:
@@ -1463,7 +1463,7 @@ YQPkgSelector::globalUpdatePkg( bool force )
 
     int count = _pkgList->globalSetPkgStatus( S_Update, force,
                                               true ); // countOnly
-    logInfo() << count << " pkgs found for update" << endl;
+    logInfo() << count << " pkgs found for update" << Qt::endl;
 
     if ( count >= GLOBAL_UPDATE_CONFIRMATION_THRESHOLD )
     {
@@ -1545,15 +1545,15 @@ YQPkgSelector::updateRepositoryUpgradeLabel()
 void
 YQPkgSelector::slotRepoUpgradeLabelLinkClicked(const QString &link)
 {
-    logDebug() << "link " << link << " clicked on label" << endl;
+    logDebug() << "link " << link << " clicked on label" << Qt::endl;
 
     QUrl url(link);
     if (url.scheme() == "repoupgradeadd")
     {
-        logDebug() << "looking for repo " << url.path() << endl;
+        logDebug() << "looking for repo " << url.path() << Qt::endl;
         std::string alias(url.path().remove(0,1).toStdString());
         zypp::Repository repo(zypp::getZYpp()->pool().reposFind(alias));
-        logDebug() << repo.name() << endl;
+        logDebug() << repo.name() << Qt::endl;
 
         if ( repo != zypp::Repository::noRepository )
         {
@@ -1571,7 +1571,7 @@ YQPkgSelector::slotRepoUpgradeLabelLinkClicked(const QString &link)
             zypp::getZYpp()->resolver()->removeUpgradeRepo(repo);
     }
     else
-        logDebug() << "unknown link operation " << url.scheme() << endl;
+        logDebug() << "unknown link operation " << url.scheme() << Qt::endl;
 
     resolveDependencies();
     emit refresh();
@@ -1709,7 +1709,7 @@ YQPkgSelector::installSubPkgs( const QString & suffix )
         {
             subPkgs[ name ] = *it;
 
-            logDebug() << "Found subpackage: " << name << endl;
+            logDebug() << "Found subpackage: " << name << Qt::endl;
         }
     }
 
@@ -1735,7 +1735,7 @@ YQPkgSelector::installSubPkgs( const QString & suffix )
                 case S_Taboo:
                 case S_Del:
                     // Don't install the subpackage
-                    logInfo() << "Ignoring unwanted subpackage " << subPkgName << endl;
+                    logInfo() << "Ignoring unwanted subpackage " << subPkgName << Qt::endl;
                     break;
 
                 case S_AutoInstall:
@@ -1747,7 +1747,7 @@ YQPkgSelector::installSubPkgs( const QString & suffix )
                     if ( ! subPkg->installedObj() )
                     {
                         subPkg->setStatus( S_Install );
-                        logInfo() << "Installing subpackage " << subPkgName << endl;
+                        logInfo() << "Installing subpackage " << subPkgName << Qt::endl;
                     }
                     break;
 
@@ -1760,12 +1760,12 @@ YQPkgSelector::installSubPkgs( const QString & suffix )
                     if ( ! subPkg->installedObj() )
                     {
                         subPkg->setStatus( S_Install );
-                        logInfo() << "Installing subpackage " << subPkgName << endl;
+                        logInfo() << "Installing subpackage " << subPkgName << Qt::endl;
                     }
                     else
                     {
                         subPkg->setStatus( S_Update );
-                        logInfo() << "Updating subpackage " << subPkgName << endl;
+                        logInfo() << "Updating subpackage " << subPkgName << Qt::endl;
                     }
                     break;
 
@@ -1795,7 +1795,7 @@ YQPkgSelector::installSubPkgs( const QString & suffix )
 bool
 YQPkgSelector::anyRetractedPkgInstalled()
 {
-    logInfo() << "Checking for retracted installed packages..." << endl;
+    logInfo() << "Checking for retracted installed packages..." << Qt::endl;
 
     for ( ZyppPoolIterator it = zyppPkgBegin(); it != zyppPkgEnd(); ++it )
     {
@@ -1803,7 +1803,7 @@ YQPkgSelector::anyRetractedPkgInstalled()
             return true;
     }
 
-    logInfo() << "No retracted packages installed." << endl;
+    logInfo() << "No retracted packages installed." << Qt::endl;
 
     return false;
 }
@@ -1907,7 +1907,7 @@ YQPkgSelector::write_etc_sysconfig_yast()
     }
     catch( const std::exception &e )
     {
-        logError() << "Writing " << PATH_TO_YAST_SYSCONFIG << " failed" << endl;
+        logError() << "Writing " << PATH_TO_YAST_SYSCONFIG << " failed" << Qt::endl;
     }
 }
 

--- a/src/YQPkgSelectorBase.cc
+++ b/src/YQPkgSelectorBase.cc
@@ -78,19 +78,19 @@ YQPkgSelectorBase::YQPkgSelectorBase( QWidget * parent,
     zyppPool().saveState<zypp::Patch    >();
 
     _blockResolver = false;
-    logInfo() << "PackageSelectorBase init done" << endl;
+    logInfo() << "PackageSelectorBase init done" << Qt::endl;
 }
 
 
 YQPkgSelectorBase::~YQPkgSelectorBase()
 {
-    logInfo() << "Destroying PackageSelectorBase" << endl;
+    logInfo() << "Destroying PackageSelectorBase" << Qt::endl;
 }
 
 
 void YQPkgSelectorBase::reset()
 {
-    logDebug() << "Sending resetNotify()" << endl;
+    logDebug() << "Sending resetNotify()" << Qt::endl;
 
     emit resetNotify();
 }
@@ -103,8 +103,13 @@ int YQPkgSelectorBase::resolveDependencies()
 
     if ( ! _pkgConflictDialog )
     {
+<<<<<<< HEAD
         logError() << "No package conflict dialog existing" << endl;
         return QDialog::Rejected;
+=======
+        logError() << "No package conflict dialog existing" << Qt::endl;
+        return QDialog::Accepted;
+>>>>>>> 1561324 (Qualify endl by using Qt::endl)
     }
 
 
@@ -124,7 +129,7 @@ int YQPkgSelectorBase::verifySystem()
 {
     if ( ! _pkgConflictDialog )
     {
-        logError() << "No package conflict dialog existing" << endl;
+        logError() << "No package conflict dialog existing" << Qt::endl;
         return QDialog::Accepted;
     }
 
@@ -200,13 +205,13 @@ bool YQPkgSelectorBase::pendingChanges()
     if ( changes )
     {
         if ( zyppPool().diffState<zypp::Package>() )
-            logInfo() << "diffState() reports changed packages" << endl;
+            logInfo() << "diffState() reports changed packages" << Qt::endl;
 
         if ( zyppPool().diffState<zypp::Pattern>() )
-            logInfo() << "diffState() reports changed patterns" << endl;
+            logInfo() << "diffState() reports changed patterns" << Qt::endl;
 
         if ( zyppPool().diffState<zypp::Patch>() )
-            logInfo() << "diffState() reports changed patches" << endl;
+            logInfo() << "diffState() reports changed patches" << Qt::endl;
     }
 
     return changes;
@@ -220,7 +225,7 @@ void YQPkgSelectorBase::reject()
 
     if ( ! YQPkgApplication::runningAsRoot() && changes )
     {
-        logInfo() << "Read-only mode (no root privileges) - abandoning changes" << endl;
+        logInfo() << "Read-only mode (no root privileges) - abandoning changes" << Qt::endl;
         changes = false;
     }
 
@@ -244,13 +249,13 @@ void YQPkgSelectorBase::reject()
         zyppPool().restoreState<zypp::Pattern  >();
         zyppPool().restoreState<zypp::Patch    >();
 
-        logInfo() << "Quitting the application" << endl;
+        logInfo() << "Quitting the application" << Qt::endl;
 
         YQPkgApplication::instance()->quit();
     }
     else
     {
-        logInfo() << "Returning to package selector" << endl;
+        logInfo() << "Returning to package selector" << Qt::endl;
 
         // User changed his mind - don't reject
     }
@@ -298,7 +303,7 @@ void YQPkgSelectorBase::accept()
 
     if ( confirmUnsupported() )
     {
-        logInfo() << "Confirm unsupported packages enabled." << endl;
+        logInfo() << "Confirm unsupported packages enabled." << Qt::endl;
         // Show which packages are unsupported
 
         QString msg =
@@ -333,12 +338,12 @@ void YQPkgSelectorBase::accept()
     if ( ! YQPkgApplication::instance()->pkgTasks()->todo().isEmpty()
          || pendingChanges() )
     {
-        logInfo() << "Closing PackageSelector with 'commit'" << endl;
+        logInfo() << "Closing PackageSelector with 'commit'" << Qt::endl;
         emit commit();
     }
     else
     {
-        logInfo() << "No changes - closing PackageSelector with 'finished'" << endl;
+        logInfo() << "No changes - closing PackageSelector with 'finished'" << Qt::endl;
         emit finished();
     }
 }
@@ -346,7 +351,7 @@ void YQPkgSelectorBase::accept()
 
 bool YQPkgSelectorBase::showPendingLicenseAgreements()
 {
-    logInfo() << "Showing all pending license agreements" << endl;
+    logInfo() << "Showing all pending license agreements" << Qt::endl;
 
     bool allConfirmed = true;
 
@@ -380,17 +385,17 @@ bool YQPkgSelectorBase::showPendingLicenseAgreements( ZyppPoolIterator begin, Zy
 
                     if ( ! licenseText.empty() )
                     {
-                        logInfo() << "Resolvable " << sel->name() << " has a license agreement" << endl;
+                        logInfo() << "Resolvable " << sel->name() << " has a license agreement" << Qt::endl;
 
                         if( ! sel->hasLicenceConfirmed() )
                         {
-                            logDebug() << "Showing license agreement for resolvable " << sel->name() << endl;
+                            logDebug() << "Showing license agreement for resolvable " << sel->name() << Qt::endl;
                             allConfirmed = YQPkgObjListItem::showLicenseAgreement( sel ) && allConfirmed;
                         }
                         else
                         {
                             logInfo() << "Resolvable " << sel->name()
-                                      << "'s  license is already confirmed" << endl;
+                                      << "'s  license is already confirmed" << Qt::endl;
                         }
                     }
                 }
@@ -421,7 +426,7 @@ void YQPkgSelectorBase::resetIgnoredDependencyProblems()
 
 void YQPkgSelectorBase::closeEvent( QCloseEvent * event )
 {
-    logInfo() << "Caught WM_CLOSE" << endl;
+    logInfo() << "Caught WM_CLOSE" << Qt::endl;
 
     event->ignore();
     reject();

--- a/src/YQPkgServiceFilterView.cc
+++ b/src/YQPkgServiceFilterView.cc
@@ -58,7 +58,7 @@ bool YQPkgServiceFilterView::any_service()
 
     // if the repository does not belong to any service then the service name is empty
 
-    // logDebug() << "Found a libzypp service: " << ret << endl;
+    // logDebug() << "Found a libzypp service: " << ret << Qt::endl;
 
     return ret;
 }

--- a/src/YQPkgServiceList.cc
+++ b/src/YQPkgServiceList.cc
@@ -42,7 +42,7 @@ using std::string;
 YQPkgServiceList::YQPkgServiceList( QWidget * parent )
     : QY2ListView( parent )
 {
-    logDebug() << "Creating service list" << endl;
+    logDebug() << "Creating service list" << Qt::endl;
 
     QStringList headers;
     headers <<  _("Name");
@@ -63,7 +63,7 @@ YQPkgServiceList::YQPkgServiceList( QWidget * parent )
     sortByColumn( nameCol(), Qt::AscendingOrder );
     selectSomething();
 
-    logDebug() << "Creating service list done" << endl;
+    logDebug() << "Creating service list done" << Qt::endl;
 }
 
 
@@ -77,7 +77,7 @@ void
 YQPkgServiceList::fillList()
 {
     clear();
-    logDebug() << "Filling service list" << endl;
+    logDebug() << "Filling service list" << Qt::endl;
 
     std::set<std::string> added_services;
     zypp::RepoManager repo_manager;
@@ -109,7 +109,7 @@ YQPkgServiceList::fillList()
                        }
                    );
 
-    logDebug() << "Service list filled" << endl;
+    logDebug() << "Service list filled" << Qt::endl;
 }
 
 
@@ -126,7 +126,7 @@ YQPkgServiceList::filter()
 {
     emit filterStart();
 
-    // logInfo() << "Collecting packages in selected services..." << endl;
+    // logInfo() << "Collecting packages in selected services..." << Qt::endl;
 
     //
     // Collect all packages from repositories belonging to this service
@@ -143,7 +143,7 @@ YQPkgServiceList::filter()
 
         if ( serviceItem )
         {
-            // logVerbose() << "Selected service: " << serviceItem->zyppService() << endl;
+            // logVerbose() << "Selected service: " << serviceItem->zyppService() << Qt::endl;
 
             zypp::PoolQuery query;
 
@@ -153,7 +153,7 @@ YQPkgServiceList::filter()
                                {
                                    if (serviceItem->zyppService() == repo.info().service())
                                    {
-                                       // logVerbose() << "Adding repo filter: " << repo.info().alias() << endl;
+                                       // logVerbose() << "Adding repo filter: " << repo.info().alias() << Qt::endl;
                                        query.addRepo( repo.info().alias() );
                                    }
                                }

--- a/src/YQPkgTextDialog.cc
+++ b/src/YQPkgTextDialog.cc
@@ -257,7 +257,7 @@ QString
 YQPkgTextDialog::htmlEscape( const QString & plainText )
 {
     QString html = plainText;
-    // logDebug() << "Escaping \"" << plainText << "\"" << endl;
+    // logDebug() << "Escaping \"" << plainText << "\"" << Qt::endl;
 
     html.replace( QRegExp( "&" ), "&amp;" );
     html.replace( QRegExp( "<" ), "&lt;"  );

--- a/src/YQPkgVersionsView.cc
+++ b/src/YQPkgVersionsView.cc
@@ -285,7 +285,7 @@ YQPkgVersionsView::checkForChangedCandidate()
 
             if ( _selectable && *newCandidate != _selectable->candidateObj() )
             {
-                logInfo() << "Candidate changed" << endl;
+                logInfo() << "Candidate changed" << Qt::endl;
 
                 // Change status of selectable
 
@@ -354,11 +354,11 @@ YQPkgVersionsView::handleMixedMultiVersion( YQPkgMultiVersion * newSelected )
     logInfo() << "Selected: "
               << ( multiVersion ? "Multiversion " : "Non-Multiversion " )
               << newSelected->text()
-              << endl;
+              << Qt::endl;
 
     if ( anyMultiVersionToInstall( !multiVersion ) )
     {
-        logInfo() << "Multiversion and non-multiversion conflict!" << endl;
+        logInfo() << "Multiversion and non-multiversion conflict!" << Qt::endl;
         bool forceContinue = mixedMultiVersionPopup( multiVersion );
 
         if ( forceContinue )
@@ -417,7 +417,7 @@ YQPkgVersionsView::mixedMultiVersionPopup( bool multiversion ) const
                                           msg,
                                           _( "C&ontinue" ),     // button #0
                                           _( "&Cancel" ) );     // button #1
-    logInfo() << "User hit " << (buttonNo == 0 ? "[Continue]" : "[Cancel]" ) << endl;
+    logInfo() << "User hit " << (buttonNo == 0 ? "[Continue]" : "[Cancel]" ) << Qt::endl;
 
     return buttonNo == 0;
 }
@@ -441,7 +441,7 @@ YQPkgVersionsView::anyMultiVersionToInstall( bool multiversion ) const
                 case S_Install:
                 case S_AutoInstall:
                     logInfo() << "Found " << ( multiversion ? "multiversion" : "non-multiversion" )
-                              << " to install" << endl;
+                              << " to install" << Qt::endl;
                     return true;
 
                 default:
@@ -453,7 +453,7 @@ YQPkgVersionsView::anyMultiVersionToInstall( bool multiversion ) const
     }
 
     logInfo() << "No " << ( multiversion ? "multiversion" : "non-multiversion" )
-              << " to install" << endl;
+              << " to install" << Qt::endl;
     return false;
 }
 
@@ -504,7 +504,7 @@ YQPkgVersionsView::isMixedMultiVersion( ZyppSel selectable )
     {
         if ( it->multiversionInstall() != multiversion )
         {
-            logInfo() << "Mixed multiversion" << endl;
+            logInfo() << "Mixed multiversion" << Qt::endl;
             return true;
         }
 
@@ -667,14 +667,14 @@ void YQPkgMultiVersion::cycleStatus()
     if ( ! handled )
         setStatus( newStatus );
 
-    logInfo() << "oldStatus: " << oldStatus << endl;
+    logInfo() << "oldStatus: " << oldStatus << Qt::endl;
     ZyppStatus actualStatus = _selectable->pickStatus( _zyppPoolItem );
 
     if ( actualStatus != newStatus )
         logWarning() << "FAILED to set new status: " << newStatus
-                     << "  actual Status: " << actualStatus << endl;
+                     << "  actual Status: " << actualStatus << Qt::endl;
     else
-        logInfo() << "newStatus:" << newStatus << endl;
+        logInfo() << "newStatus:" << newStatus << Qt::endl;
 
     if ( oldStatus != actualStatus )
     {
@@ -686,7 +686,7 @@ void YQPkgMultiVersion::cycleStatus()
 
 void YQPkgMultiVersion::setStatus( ZyppStatus newStatus )
 {
-    logInfo() << "Setting pick status to " << newStatus << endl;
+    logInfo() << "Setting pick status to " << newStatus << Qt::endl;
     _selectable->setPickStatus( _zyppPoolItem, newStatus );
 }
 

--- a/src/ZyppLogger.cc
+++ b/src/ZyppLogger.cc
@@ -30,7 +30,7 @@ ZyppLogger::ZyppLogger()
     , _lineFormatter( new ZyppLogLineFormatter() )
     , _zyppThreadLogger( Logger::lastLogDir(), "zypp.log" )
 {
-    logInfo() << "Installing the zypp logger" << endl;
+    logInfo() << "Installing the zypp logger" << Qt::endl;
 
     zypp::base::LogControl::instance().setLineFormater( _lineFormatter );
     zypp::base::LogControl::instance().setLineWriter  ( _lineWriter    );
@@ -39,7 +39,7 @@ ZyppLogger::ZyppLogger()
 
 ZyppLogger::~ZyppLogger()
 {
-    logInfo() << "Uninstalling the zypp logger" << endl;
+    logInfo() << "Uninstalling the zypp logger" << Qt::endl;
 
     // Avoid error "QMutex: destroying locked mutex" in the (main) log:
     // The zypp thread might still be writing log messages.
@@ -59,7 +59,7 @@ void ZyppLogger::logLine( const std::string & message )
 {
     QMutexLocker locker( &_mutex );
 
-    _zyppThreadLogger.logStream() << fromUTF8( message ) << endl;
+    _zyppThreadLogger.logStream() << fromUTF8( message ) << Qt::endl;
 }
 
 

--- a/src/attic/YQPatternSelector.cc
+++ b/src/attic/YQPatternSelector.cc
@@ -62,7 +62,7 @@ YQPatternSelector::YQPatternSelector( QWidget *	parent, long modeFlags )
 
     if ( zyppPool().empty<zypp::Pattern  >() )
     {
-	logWarning() << "Neither patterns nor selections in ZyppPool" << endl;
+	logWarning() << "Neither patterns nor selections in ZyppPool" << Qt::endl;
     }
 
 
@@ -243,14 +243,14 @@ YQPatternSelector::makeConnections()
 
     }
 
-    logInfo() << "Connection set up" << endl;
+    logInfo() << "Connection set up" << Qt::endl;
 }
 
 
 void
 YQPatternSelector::detailedPackageSelection()
 {
-    logInfo() << "\"Details..\" button clicked" << endl;
+    logInfo() << "\"Details..\" button clicked" << Qt::endl;
 
     // FIXME: Open a YQPackageSelector
 }
@@ -259,7 +259,7 @@ YQPatternSelector::detailedPackageSelection()
 void
 YQPatternSelector::debugTrace()
 {
-    logWarning() << "debugTrace" << endl;
+    logWarning() << "debugTrace" << Qt::endl;
 }
 
 

--- a/src/attic/YQPkgSelDescriptionView.cc
+++ b/src/attic/YQPkgSelDescriptionView.cc
@@ -100,7 +100,7 @@ YQPkgSelDescriptionView::htmlHeading( ZyppSel selectable )
 	    iconName.replace( QRegExp( "^\\./" ), "" );
 
 	if ( pattern && iconName.isEmpty() )
-	    logWarning() << "No icon for pattern " << zyppObj->name() << endl;
+	    logWarning() << "No icon for pattern " << zyppObj->name() << Qt::endl;
     }
 
 

--- a/src/attic/YQPkgUpdateProblemFilterView.cc
+++ b/src/attic/YQPkgUpdateProblemFilterView.cc
@@ -89,7 +89,7 @@ YQPkgUpdateProblemFilterView::filter()
 	    {
 		logInfo() << "Problematic package: "
                           << pkg->name() << "-" << pkg->edition().asString()
-                          << endl;
+                          << Qt::endl;
 
 		emit filterMatch( sel, pkg );
 	    }

--- a/src/attic/YQSimplePatchSelector.cc
+++ b/src/attic/YQSimplePatchSelector.cc
@@ -177,14 +177,14 @@ YQSimplePatchSelector::makeConnections()
 		 _diskUsageList, SLOT  ( updateDiskUsage() ) );
     }
 
-    logInfo() << "Connection set up" << endl;
+    logInfo() << "Connection set up" << Qt::endl;
 }
 
 
 void
 YQSimplePatchSelector::detailedPackageSelection()
 {
-    logInfo() << "\"Details..\" button clicked" << endl;
+    logInfo() << "\"Details..\" button clicked" << Qt::endl;
     YQUI::ui()->sendEvent( new YMenuEvent( "details" ) );
 }
 
@@ -192,7 +192,7 @@ YQSimplePatchSelector::detailedPackageSelection()
 void
 YQSimplePatchSelector::debugTrace()
 {
-    logWarning() << "debugTrace" << endl;
+    logWarning() << "debugTrace" << Qt::endl;
 }
 
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -74,12 +74,12 @@ bool commandLineOption( const QString & longName,
         if ( ! shortName.isEmpty() )
             argList.removeAll( shortName );
 
-        logDebug() << "Found " << longName << endl;
+        logDebug() << "Found " << longName << Qt::endl;
 	return true;
     }
     else
     {
-        // logDebug() << "No " << longName << endl;
+        // logDebug() << "No " << longName << Qt::endl;
 	return false;
     }
 }
@@ -100,7 +100,7 @@ parseCommandLineOptions( QStringList & argList )
 
     if ( ! argList.isEmpty() )
     {
-        logError() << "FATAL: Bad command line args: " << argList.join( " " ) << endl;
+        logError() << "FATAL: Bad command line args: " << argList.join( " " ) << Qt::endl;
         usage();
     }
 
@@ -115,7 +115,7 @@ void logVersion()
 
     logInfo() << progName << "-" << VERSION
               << " built with Qt " << QT_VERSION_STR
-              << endl;
+              << Qt::endl;
 }
 
 
@@ -145,7 +145,7 @@ int main( int argc, char *argv[] )
         app.run();
     }
 
-    logDebug() << "YQPkgApplication finished." << endl;
+    logDebug() << "YQPkgApplication finished." << Qt::endl;
 
     return 0;
 }

--- a/test/workflow-tester/workflow-tester.cc
+++ b/test/workflow-tester/workflow-tester.cc
@@ -38,13 +38,13 @@ public:
 
 void TestWfStep::activate( bool goingForward )
 {
-    logDebug() << "  +++ " << _id << endl;
+    logDebug() << "  +++ " << _id << Qt::endl;
 }
 
 
 void TestWfStep::deactivate( bool goingForward )
 {
-    logDebug() << "--- " << _id << endl;
+    logDebug() << "--- " << _id << Qt::endl;
 }
 
 
@@ -67,7 +67,7 @@ int main( int argc, char *argv[] )
     workflow->start();
 
 
-    logDebug() << "Going through the workflow past the end" << endl;
+    logDebug() << "Going through the workflow past the end" << Qt::endl;
 
     for ( int i=0; i < workflowSteps.size() + 2; i++ )
     {
@@ -76,7 +76,7 @@ int main( int argc, char *argv[] )
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Going back 3 steps" << endl;
+    logDebug() << "Going back 3 steps" << Qt::endl;
 
     for ( int i=0; i < 3; i++ )
     {
@@ -85,35 +85,35 @@ int main( int argc, char *argv[] )
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Going to page 104 directly" << endl;
+    logDebug() << "Going to page 104 directly" << Qt::endl;
 
     workflow->gotoStep( "Page 104" );
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Restarting the workflow" << endl;
+    logDebug() << "Restarting the workflow" << Qt::endl;
 
     workflow->restart();
 
     logDebug() << "The history should be empty now: "
                << QString( workflow->historyEmpty() ? "empty" : "not empty" )
-               << endl;
+               << Qt::endl;
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Trying to go back 2 times" << endl;
+    logDebug() << "Trying to go back 2 times" << Qt::endl;
     workflow->back();
     workflow->back();
 
-    logDebug() << "Current step: " << workflow->currentStep()->id() << endl;
+    logDebug() << "Current step: " << workflow->currentStep()->id() << Qt::endl;
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Going forward until the end" << endl;
+    logDebug() << "Going forward until the end" << Qt::endl;
 
     while ( ! workflow->atLastStep() )
     {
-        logDebug() << "Next" << endl;
+        logDebug() << "Next" << Qt::endl;
 
         workflow->next();
     }
@@ -121,11 +121,11 @@ int main( int argc, char *argv[] )
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Going backward until the start of the history" << endl;
+    logDebug() << "Going backward until the start of the history" << Qt::endl;
 
     while ( ! workflow->historyEmpty() )
     {
-        logDebug() << "Back" << endl;
+        logDebug() << "Back" << Qt::endl;
 
         workflow->back();
     }
@@ -133,7 +133,7 @@ int main( int argc, char *argv[] )
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Going on a wild ride" << endl;
+    logDebug() << "Going on a wild ride" << Qt::endl;
 
     workflow->gotoStep( "Rare Page 99" ); // the one that is usually skipped
     workflow->gotoStep( "Page 104" );
@@ -144,7 +144,7 @@ int main( int argc, char *argv[] )
 
     sleep( 1 );
     logNewline();
-    logDebug() << "Going backward until the start of the history" << endl;
+    logDebug() << "Going backward until the start of the history" << Qt::endl;
 
     while ( ! workflow->historyEmpty() )
     {


### PR DESCRIPTION
Qualify `endl`, `dec`, `hex` by using `Qt::endl`, `Qt::dec`, `Qt::hex`.
Qt 6 does not support the old form.