### PR TITLE
Replace excessive use of QRegExp by simple QString methods

### DIFF
--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -483,7 +483,7 @@ QString Logger::oldName( const QString & filename, int no )
     QString oldName = filename;
 
     if ( oldName.endsWith( ".log" ) )
-	oldName.remove( QRegExp( "\\.log$" ) );
+        oldName.truncate( sizeof( ".log" ) );
 
     oldName += QString( "-%1.old" ).arg( no, 2, 10, QChar( '0' ) );
 
@@ -496,7 +496,7 @@ QString Logger::oldNamePattern( const QString & filename )
     QString pattern = filename;
 
     if ( pattern.endsWith( ".log" ) )
-	pattern.remove( QRegExp( "\\.log$" ) );
+        pattern.truncate( sizeof( ".log" ) );
 
     pattern += "-??.old";
 

--- a/src/SearchFilter.cc
+++ b/src/SearchFilter.cc
@@ -49,7 +49,8 @@ void SearchFilter::guessFilterMode()
 
     if ( _filterMode == ExactMatch && _pattern.startsWith( "=" ) )
     {
-        _pattern.remove( QRegExp( "^=" ) );
+        // remove leading equals sign
+        _pattern.remove( 0, 1 ); // FIXME: Use _pattern.removeFirst() once Qt >= 6.5 is required
         _regexp.setPattern( _pattern );
     }
 }

--- a/src/YQPkgGenericDetailsView.cc
+++ b/src/YQPkgGenericDetailsView.cc
@@ -16,7 +16,6 @@
 
 
 #include <QTabWidget>
-#include <QRegExp>
 
 #include "Logger.h"
 #include "YQi18n.h"
@@ -165,9 +164,9 @@ YQPkgGenericDetailsView::htmlEscape( const QString & plainText )
     QString html = plainText;
     // logDebug() << "Escaping \"" << plainText << "\"" << endl;
 
-    html.replace( QRegExp( "&" ), "&amp;" );
-    html.replace( QRegExp( "<" ), "&lt;"  );
-    html.replace( QRegExp( ">" ), "&gt;"  );
+    html.replace( "&", "&amp;" );
+    html.replace( "<", "&lt;" );
+    html.replace( ">", "&gt;" );
 
     return html;
 }

--- a/src/YQPkgTextDialog.cc
+++ b/src/YQPkgTextDialog.cc
@@ -21,7 +21,6 @@
 #include <QKeyEvent>
 #include <QLayout>
 #include <QPushButton>
-#include <QRegExp>
 #include <QTextBrowser>
 
 #include "Exception.h"
@@ -259,9 +258,9 @@ YQPkgTextDialog::htmlEscape( const QString & plainText )
     QString html = plainText;
     // logDebug() << "Escaping \"" << plainText << "\"" << endl;
 
-    html.replace( QRegExp( "&" ), "&amp;" );
-    html.replace( QRegExp( "<" ), "&lt;"  );
-    html.replace( QRegExp( ">" ), "&gt;"  );
+    html.replace( "&", "&amp;" );
+    html.replace( "<", "&lt;" );
+    html.replace( ">", "&gt;" );
 
     return html;
 }


### PR DESCRIPTION
Use simple QString methods to remove fixed number of leading or trailing characters, and replacing substrings. Creating QRegExp objects is expensive.

Preparation of a future port to Qt 6.