### PR TITLE
Replace deprecated constructor QFlags(0) by default constructor

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -88,7 +88,7 @@ bool commandLineOption( const QString & longName,
 YQPkgAppOptions
 parseCommandLineOptions( QStringList & argList )
 {
-    YQPkgAppOptions optFlags( 0 );
+    YQPkgAppOptions optFlags;
 
     if ( commandLineOption( "--read-only",     "-r", argList ) ) optFlags |= OptReadOnly;
     if ( commandLineOption( "--dry-run",       "-n", argList ) ) optFlags |= OptDryRun;


### PR DESCRIPTION
Deprecated since Qt 5.15.