### PR TITLE
Add libqt5-qtbase-devel as dependency in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ libzypp-devel.
 
 ```
 sudo zypper install -t pattern devel_C_C++ devel_qt5
-sudo zypper install cmake libzypp-devel
+sudo zypper install cmake libzypp-devel libqt5-qtbase-devel
 ```
 
 


### PR DESCRIPTION
Tried building on a currenet TW system, installing deps from README.
Cmake still couldn't find Qt5Config.cmake.
Looks like libqt5-qtbase-devel covers enough of the qt5 devel libs to
make it compile.