### PR TITLE
Replace deprecated QDesktopWidget

### DIFF
--- a/src/QY2LayoutUtils.cc
+++ b/src/QY2LayoutUtils.cc
@@ -16,8 +16,8 @@
 
 
 #include <QApplication>
+#include <QScreen>
 #include <QWidget>
-#include <QDesktopWidget>
 
 #include "QY2LayoutUtils.h"
 #include "Logger.h"
@@ -73,7 +73,7 @@ limitToScreenSize( const QWidget * widget, int width, int height )
 QSize
 limitToScreenSize( const QWidget * widget, const QSize & desiredSize )
 {
-    QSize availableSize = QApplication::desktop()->availableGeometry( const_cast<QWidget*> (widget) ).size();
+    QSize availableSize = widget->screen()->availableGeometry().size();
 
     // Subtract WM decorations. There seems to be no reliable way to tell if
     // this is necessary at all (even fvwm2 claims it is a NETWM compliant

--- a/src/YQPkgConflictDialog.cc
+++ b/src/YQPkgConflictDialog.cc
@@ -29,7 +29,6 @@
 #include <QElapsedTimer>
 #include <QPainter>
 #include <QMessageBox>
-#include <QDesktopWidget>
 #include <QPixmap>
 #include <QBoxLayout>
 

--- a/src/YQPkgDescriptionDialog.cc
+++ b/src/YQPkgDescriptionDialog.cc
@@ -15,11 +15,10 @@
  */
 
 
-#include <QApplication>
-#include <QDesktopWidget>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QScreen>
 #include <QSplitter>
 #include <QStyle>
 #include <QList>
@@ -142,7 +141,7 @@ YQPkgDescriptionDialog::isEmpty() const
 QSize
 YQPkgDescriptionDialog::sizeHint() const
 {
-    QRect available = qApp->desktop()->availableGeometry( (QWidget *) this );
+    QRect available = this->screen()->availableGeometry();
     QSize size = QDialog::sizeHint();
     size = size.boundedTo( QSize( available.width(), available.height() ) );
 

--- a/src/YQPkgProductDialog.cc
+++ b/src/YQPkgProductDialog.cc
@@ -15,12 +15,11 @@
  */
 
 
-#include <QApplication>
-#include <QDesktopWidget>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QList>
 #include <QPushButton>
+#include <QScreen>
 #include <QSplitter>
 #include <QTabWidget>
 
@@ -130,7 +129,7 @@ YQPkgProductDialog::polish()
 QSize
 YQPkgProductDialog::sizeHint() const
 {
-    QRect available = qApp->desktop()->availableGeometry( (QWidget *) this );
+    QRect available = this->screen()->availableGeometry();
     QSize size = QDialog::sizeHint();
     size = size.boundedTo( QSize( available.width(), available.height() ) );
 


### PR DESCRIPTION
Use QScreen instead.

This is a preparation for the Qt 6 port.