### PR TITLE
logger: Remove deprecated strerror

### DIFF
--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -593,12 +593,7 @@ QTextStream & operator<<( QTextStream & str, const std::string & text )
 }
 
 
-// Un-deprecate strerror() just for this one call.
-#ifdef strerror
-#    undef strerror
-#endif
-
 QString formatErrno()
 {
-    return QString::fromUtf8( strerror( errno ) );
+    return QString( errno );
 }

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -326,17 +326,8 @@ QTextStream & operator<<( QTextStream & str, const std::string & text );
 
 /**
  * Format errno as a QString.
- * This is a replacement for strerror() that handles UTF-8 well:
- * In Qt 5.x, const char * is automatically converted to UTF-8 for QString.
- * In Qt 4.x, however, it uses simply fromAscii() which is almost never correct.
  **/
 QString formatErrno();
 
-#ifndef DONT_DEPRECATE_STRERROR
-    // Use formatErrno() instead which deals with UTF-8 issues
-    char * strerror(int) __attribute__ ((deprecated));
-#endif
-
 
 #endif // Logger_h
-


### PR DESCRIPTION
It provided backwards compatibility for Qt < 5

Fixes #37 